### PR TITLE
Fixing squid: S1213  The members of an interface declaration or class should appear in a pre-defined order part 1

### DIFF
--- a/asn1-datatypes/src/main/java/net/gcdc/asn1/datatypes/Alphabet.java
+++ b/asn1-datatypes/src/main/java/net/gcdc/asn1/datatypes/Alphabet.java
@@ -4,11 +4,12 @@ public abstract class Alphabet {
 
     private final String chars;
 
+    protected Alphabet(String chars) {
+        this.chars = chars;
+    }
+
     public final String chars() {
         return chars;
     }
 
-    protected Alphabet(String chars) {
-        this.chars = chars;
-    }
 }

--- a/asn1-datatypes/src/main/java/net/gcdc/asn1/datatypes/AlphabetBuilder.java
+++ b/asn1-datatypes/src/main/java/net/gcdc/asn1/datatypes/AlphabetBuilder.java
@@ -3,9 +3,9 @@ package net.gcdc.asn1.datatypes;
 
 public class AlphabetBuilder {
 
-    public AlphabetBuilder() {}
-
     private final StringBuilder sb = new StringBuilder();
+
+    public AlphabetBuilder() {}
 
     public String chars() {
         return sb.toString();

--- a/asn1-datatypes/src/main/java/net/gcdc/asn1/datatypes/Asn1BigInteger.java
+++ b/asn1-datatypes/src/main/java/net/gcdc/asn1/datatypes/Asn1BigInteger.java
@@ -3,17 +3,17 @@ package net.gcdc.asn1.datatypes;
 import java.math.BigInteger;
 
 public abstract class Asn1BigInteger {
-    @Override public String toString() {
-        return "" + value;
-    }
 
     private final BigInteger value;
-
-    public BigInteger value() { return value; }
 
     public Asn1BigInteger(final BigInteger value) {
         this.value = value;
     }
 
+    @Override public String toString() {
+        return "" + value;
+    }
+
+    public BigInteger value() { return value; }
 
 }

--- a/asn1-datatypes/src/main/java/net/gcdc/asn1/datatypes/Asn1Integer.java
+++ b/asn1-datatypes/src/main/java/net/gcdc/asn1/datatypes/Asn1Integer.java
@@ -1,19 +1,25 @@
 package net.gcdc.asn1.datatypes;
 
 public abstract class Asn1Integer {
+
+    public long value;
+
+    public Asn1Integer() {}
+    public Asn1Integer(long value) {
+        this.value = value;
+    }
+
+    public long value() { return value; }
+
     @Override public String toString() {
         return "" + value;
     }
 
-    public long value;
 
-    public long value() { return value; }
 
-    public Asn1Integer() {}
 
-    public Asn1Integer(long value) {
-        this.value = value;
-    }
+
+
 
 
 }

--- a/asn1-datatypes/src/main/java/net/gcdc/asn1/datatypes/Asn1String.java
+++ b/asn1-datatypes/src/main/java/net/gcdc/asn1/datatypes/Asn1String.java
@@ -2,15 +2,16 @@ package net.gcdc.asn1.datatypes;
 
 public class Asn1String {
 
-    @Override public String toString() { return value; }
-
     private String value;
 
-    public String value() { return value; }
+    public Asn1String() { this(""); }
 
     public Asn1String(String value) {
         this.value = value;
     }
 
-    public Asn1String() { this(""); }
+    @Override public String toString() { return value; }
+
+    public String value() { return value; }
+
 }

--- a/geonetworking/src/main/java/net/gcdc/PlugTestCMS4.java
+++ b/geonetworking/src/main/java/net/gcdc/PlugTestCMS4.java
@@ -10,20 +10,9 @@ import net.gcdc.plugtestcms4.ping.*;
 public class PlugTestCMS4
   extends JFrame
 {
-
+  private final List<DUT> dutList = new ArrayList<> ();
   final JTabbedPane tabbedPane;
   final DUTsPane dutsPane;
-
-  public static void main (String[] args)
-  {
-    SwingUtilities.invokeLater (new Runnable ()
-      {
-        public void run ()
-        {
-          new PlugTestCMS4 ().setVisible (true);
-        }
-      });
-  }
 
   public PlugTestCMS4 ()
   {
@@ -38,6 +27,19 @@ public class PlugTestCMS4
     setContentPane (this.tabbedPane);
     pack ();
   }
+
+  public static void main (String[] args)
+  {
+    SwingUtilities.invokeLater (new Runnable ()
+      {
+        public void run ()
+        {
+          new PlugTestCMS4 ().setVisible (true);
+        }
+      });
+  }
+
+
 
   private class DUTsPane
   extends JComponent
@@ -87,7 +89,5 @@ public class PlugTestCMS4
     }
 
   }
-
-  private final List<DUT> dutList = new ArrayList<> ();
 
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1213  "The members of an interface declaration or class should appear in a pre-defined order" . This PR will remove 1h TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1213
 Please let me know if you have any questions.
Fevzi Ozgul