### PR TITLE
Fixing squid: S1213 Members of classes and interfaces should be in a predefined order part 3 final

### DIFF
--- a/camdenm/src/main/java/net/gcdc/camdenm/Iclcm.java
+++ b/camdenm/src/main/java/net/gcdc/camdenm/Iclcm.java
@@ -160,10 +160,7 @@ public class Iclcm {
 			this(new VehicleRearAxleLocation(),new ControllerType(), 
 					new VehicleResponseTime(), new TargetLongitudonalAcceleration(), new TimeHeadway(), new CruiseSpeed());
 		}
-		@Override public String toString() { return "VehicleContainerHighFrequency(" + vehicleRearAxleLocation + ", " 
-				+ controllerType + ", " + vehicleResponseTime + ", " + targetLongitudinalAcceleration + ", " 
-						+ timeHeadway + ", " + cruisespeed + ")"; }
-		
+			
 		public VehicleContainerHighFrequency(VehicleRearAxleLocation vehicleRearAxleLocation,ControllerType controllerType,
 				VehicleResponseTime vehicleResponseTime,TargetLongitudonalAcceleration targetLongitudinalAcceleration,
 				TimeHeadway timeHeadway,CruiseSpeed cruisespeed){
@@ -198,6 +195,10 @@ public class Iclcm {
 		public CruiseSpeed getCruisespeed() {
 			return cruisespeed;
 		}
+		
+		@Override public String toString() { return "VehicleContainerHighFrequency(" + vehicleRearAxleLocation + ", " 
+				+ controllerType + ", " + vehicleResponseTime + ", " + targetLongitudinalAcceleration + ", " 
+						+ timeHeadway + ", " + cruisespeed + ")"; }
 	}
 	@Sequence
     public static class VehicleContainerLowFrequency{

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/Area.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/Area.java
@@ -11,18 +11,20 @@ import java.nio.ByteBuffer;
  */
 public final class Area {
 
-    @Override public String toString() {
-        return "Area [center=" + center + ", distanceAmeters=" + distanceAmeters
-                + ", distanceBmeters=" + distanceBmeters + ", angleDegreesFromNorth="
-                + angleDegreesFromNorth + ", type=" + type + "]";
-    }
-
     private final Position center;
     private final double   distanceAmeters;
     private final double   distanceBmeters;
     private final double   angleDegreesFromNorth;
     private final Type     type;
-
+    
+    private Area(Position center, double distanceA, double distanceB, double angleDegreesFromNorth, Type type) {
+        this.center    = center;
+        this.distanceAmeters = distanceA;
+        this.distanceBmeters = distanceB;
+        this.angleDegreesFromNorth = angleDegreesFromNorth;
+        this.type = type;
+    }
+    
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -73,15 +75,6 @@ public final class Area {
             for (Area.Type h: Area.Type.values()) { if (h.code() == code) { return h; } }
             throw new IllegalArgumentException("Can't recognize area type: " + code);
         }
-    }
-
-
-    private Area(Position center, double distanceA, double distanceB, double angleDegreesFromNorth, Type type) {
-        this.center    = center;
-        this.distanceAmeters = distanceA;
-        this.distanceBmeters = distanceB;
-        this.angleDegreesFromNorth = angleDegreesFromNorth;
-        this.type = type;
     }
 
     public static Area getFrom(ByteBuffer buffer, Area.Type type) {
@@ -177,5 +170,10 @@ side);
         return new Area(center, longSemiAxisMeters, shortSemiAxisMeters,
                 azimuthAngleDegreesFromNorth, Type.ELLIPSE);
     }
-
+    
+    @Override public String toString() {
+        return "Area [center=" + center + ", distanceAmeters=" + distanceAmeters
+                + ", distanceBmeters=" + distanceBmeters + ", angleDegreesFromNorth="
+                + angleDegreesFromNorth + ", type=" + type + "]";
+    }
 }

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/BasicHeader.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/BasicHeader.java
@@ -11,6 +11,18 @@ public class BasicHeader {
                                                 // octet 1 (reserved)
     private final Lifetime   lifetime;          // octet 2
     private final byte       remainingHopLimit; // octet 3
+    
+    public BasicHeader(
+            byte version,
+            NextHeader nextHeader,
+            Lifetime lifetime,
+            byte remainingHopLimit
+            ) {
+        this.version              = version;
+        this.nextHeader           = nextHeader;
+        this.lifetime             = lifetime;
+        this.remainingHopLimit    = remainingHopLimit;
+    }
 
     public byte       version()           { return version;           }
     public NextHeader nextHeader()        { return nextHeader;        }
@@ -97,20 +109,6 @@ public class BasicHeader {
                 }
             }
         }
-
-        
-        public BasicHeader(
-                byte version,
-                NextHeader nextHeader,
-                Lifetime lifetime,
-                byte remainingHopLimit
-                ) {
-            this.version              = version;
-            this.nextHeader           = nextHeader;
-            this.lifetime             = lifetime;
-            this.remainingHopLimit    = remainingHopLimit;
-        }
-
         private Lifetime(Base base, byte multiplier) {
             this.base       = base;
             this.multiplier = multiplier;

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/BasicHeader.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/BasicHeader.java
@@ -68,6 +68,14 @@ public class BasicHeader {
      */
     public static class Lifetime {
 
+        
+        final static double MAX_MULTIPLIER = 63;  // Max unsigned 6-bit integer.
+
+        public final static Lifetime MAX_VALUE = new Lifetime(Base.X100S, (byte)MAX_MULTIPLIER);
+
+        private final byte multiplier;  // bits 0-5
+        private final Base base;        // bits 6-7
+        
         public static enum Base {
             X50MS  (  0.050, 0),  // Up to 3.15 seconds.
             X1S    (  1.000, 1),  // From 4 up to 63 seconds.
@@ -90,12 +98,18 @@ public class BasicHeader {
             }
         }
 
-        final static double MAX_MULTIPLIER = 63;  // Max unsigned 6-bit integer.
-
-        public final static Lifetime MAX_VALUE = new Lifetime(Base.X100S, (byte)MAX_MULTIPLIER);
-
-        private final byte multiplier;  // bits 0-5
-        private final Base base;        // bits 6-7
+        
+        public BasicHeader(
+                byte version,
+                NextHeader nextHeader,
+                Lifetime lifetime,
+                byte remainingHopLimit
+                ) {
+            this.version              = version;
+            this.nextHeader           = nextHeader;
+            this.lifetime             = lifetime;
+            this.remainingHopLimit    = remainingHopLimit;
+        }
 
         private Lifetime(Base base, byte multiplier) {
             this.base       = base;
@@ -128,17 +142,6 @@ public class BasicHeader {
 
     }
 
-    public BasicHeader(
-            byte version,
-            NextHeader nextHeader,
-            Lifetime lifetime,
-            byte remainingHopLimit
-            ) {
-        this.version              = version;
-        this.nextHeader           = nextHeader;
-        this.lifetime             = lifetime;
-        this.remainingHopLimit    = remainingHopLimit;
-    }
 
     public ByteBuffer putTo(ByteBuffer buffer) {
         byte versionAndNextHeader = (byte) (version << 4 | nextHeader.value());

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/BtpPacket.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/BtpPacket.java
@@ -4,6 +4,8 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 public class BtpPacket {
+	
+	public static final int HEADER_LENGTH = 4;
 
     private final Optional<Short>              sourcePort;
     private final short                        destinationPort;
@@ -133,8 +135,6 @@ public class BtpPacket {
         }
         return gnPayload;
     }
-
-    public static final int HEADER_LENGTH = 4;
 
     private ByteBuffer putHeaderTo(ByteBuffer buffer) {
         return buffer.putShort(destinationPort)

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/CommonHeader.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/CommonHeader.java
@@ -12,14 +12,7 @@ public final class CommonHeader {
 
     /** Header length in bytes. */
     public static final int LENGTH = 8;
-
-    public UpperProtocolType nextHeader()      { return nextHeader;      }
-    public DestinationType   typeAndSubtype()  { return typeAndSubtype;  }
-    public TrafficClass      trafficClass()    { return trafficClass;    }
-    public boolean           isMobile()        { return isMobile;        }
-    public short             payloadLength()   { return payloadLength;   }
-    public byte              maximumHopLimit() { return maximumHopLimit; }
-
+    
     public CommonHeader(
             UpperProtocolType nextHeader,
             DestinationType   typeAndSubtype,
@@ -35,6 +28,13 @@ public final class CommonHeader {
         this.payloadLength   = payloadLength;
         this.maximumHopLimit = maximumHopLimit;
     }
+
+    public UpperProtocolType nextHeader()      { return nextHeader;      }
+    public DestinationType   typeAndSubtype()  { return typeAndSubtype;  }
+    public TrafficClass      trafficClass()    { return trafficClass;    }
+    public boolean           isMobile()        { return isMobile;        }
+    public short             payloadLength()   { return payloadLength;   }
+    public byte              maximumHopLimit() { return maximumHopLimit; }
 
     public ByteBuffer putTo(ByteBuffer buffer) {
         byte  nextHeaderAndReserved = (byte) (nextHeader.value() << 4);

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/Destination.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/Destination.java
@@ -2,6 +2,12 @@ package net.gcdc.geonetworking;
 
 
 public abstract class Destination {
+	
+	final private Area              area;
+    final private Optional<Double>  maxLifetimeSeconds;
+    final private Optional<Byte>    maxHopLimit;
+    final private Optional<Byte>    remainingHopLimit;
+    final private boolean           isAnycast;
 
     public abstract DestinationType  typeAndSubtype();
     public abstract Optional<Double> maxLifetimeSeconds();
@@ -43,6 +49,21 @@ public abstract class Destination {
     }
 
     public static final class Geobroadcast extends Destination {
+    	
+    	private Geobroadcast (
+                Area              area,
+                Optional<Double>  maxLifetimeSeconds,
+                Optional<Byte>    maxHopLimit,
+                Optional<Byte>    remainingHopLimit,
+                boolean           isAnycast
+                ) {
+            this.area               = area;
+            this.maxLifetimeSeconds = maxLifetimeSeconds;
+            this.maxHopLimit        = maxHopLimit;
+            this.remainingHopLimit  = remainingHopLimit;
+            this.isAnycast          = isAnycast;
+        }
+    	
         @Override
         public int hashCode() {
             final int prime = 31;
@@ -89,25 +110,6 @@ public abstract class Destination {
             } else if (!remainingHopLimit.equals(other.remainingHopLimit))
                 return false;
             return true;
-        }
-        final private Area              area;
-        final private Optional<Double>  maxLifetimeSeconds;
-        final private Optional<Byte>    maxHopLimit;
-        final private Optional<Byte>    remainingHopLimit;
-        final private boolean           isAnycast;
-
-        private Geobroadcast (
-                Area              area,
-                Optional<Double>  maxLifetimeSeconds,
-                Optional<Byte>    maxHopLimit,
-                Optional<Byte>    remainingHopLimit,
-                boolean           isAnycast
-                ) {
-            this.area               = area;
-            this.maxLifetimeSeconds = maxLifetimeSeconds;
-            this.maxHopLimit        = maxHopLimit;
-            this.remainingHopLimit  = remainingHopLimit;
-            this.isAnycast          = isAnycast;
         }
 
         public Area area() { return area; }

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/Destination.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/Destination.java
@@ -2,12 +2,6 @@ package net.gcdc.geonetworking;
 
 
 public abstract class Destination {
-	
-	final private Area              area;
-    final private Optional<Double>  maxLifetimeSeconds;
-    final private Optional<Byte>    maxHopLimit;
-    final private Optional<Byte>    remainingHopLimit;
-    final private boolean           isAnycast;
 
     public abstract DestinationType  typeAndSubtype();
     public abstract Optional<Double> maxLifetimeSeconds();

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/GeonetStation.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/GeonetStation.java
@@ -50,12 +50,10 @@ public class GeonetStation implements Runnable, AutoCloseable {
             Executors.newSingleThreadScheduledExecutor();
 
     private boolean isPromiscuous = true;
-
-    // Common function to get the current time.
-    private Instant timeInstantNow() {
-        return Instant.now();  // Add clock here for non-real-time.
-    }
-
+ // Do we need concurrent?
+    private final Map<PacketId, ScheduledFuture<?>> contentionSet = new ConcurrentHashMap<>();
+    private final Set<PacketId> seenPackets = new HashSet<>();
+    
     public GeonetStation(StationConfig config, LinkLayer linkLayer, PositionProvider positionProvider) {
         this(config, linkLayer, positionProvider, EMPTY_MAC);
     }
@@ -72,6 +70,11 @@ public class GeonetStation implements Runnable, AutoCloseable {
             @Override public StationConfig config() { return GeonetStation.this.config;}
         });
         logger.info("Initialized station with GN address {} and MAC address {}", config.itsGnLoacalGnAddr, this.senderMac);
+    }
+
+    // Common function to get the current time.
+    private Instant timeInstantNow() {
+        return Instant.now();  // Add clock here for non-real-time.
     }
 
     private short sequenceNumber() {
@@ -365,9 +368,6 @@ public class GeonetStation implements Runnable, AutoCloseable {
         }
     }
 
-    // Do we need concurrent?
-    private final Map<PacketId, ScheduledFuture<?>> contentionSet = new ConcurrentHashMap<>();
-
     private void sendForwardedPacket(GeonetData data, int sequenceNumber, Instant timeAdded, MacAddress dstMac) {
         if (!linkLayer.hasEthernetHeader()) { return; }  // Forwarding does not work without MAC.
         double queuingTimeInSeconds = Duration.between(timeAdded, timeInstantNow()).toMillis() * 0.001;
@@ -586,8 +586,6 @@ public class GeonetStation implements Runnable, AutoCloseable {
             logger.error("Exception in LinkLayer close()", e);
         }
     }
-
-    private final Set<PacketId> seenPackets = new HashSet<>();
 
     private class PacketId {
         private final Instant timestamp;

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/LocationTable.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/LocationTable.java
@@ -51,6 +51,16 @@ public class LocationTable {
         private final boolean isNeighbour;
         private final int sequenceNumber;
         private final Instant timestamp;
+        
+        private Entry(Builder builder) {
+            this.address = builder.address;
+            this.macAddress = builder.macAddress;
+            this.position = builder.position;
+            this.locationServicePending = builder.locationServicePending;
+            this.isNeighbour = builder.isNeighbour;
+            this.sequenceNumber = builder.sequenceNumber;
+            this.timestamp = builder.timestamp;
+        }
 
         public Address address() { return address; }
         public MacAddress macAddress() { return macAddress; }
@@ -64,17 +74,7 @@ public class LocationTable {
         public Entry withPosition(LongPositionVector position) { return new Builder(this).position(position).create(); }
         public Entry withIsNeighbour(boolean isNeighbour) { return new Builder(this).isNeighbour(isNeighbour).create(); }
         public Entry withTimestamp(Instant timestamp) { return new Builder(this).timestamp(timestamp).create(); }
-
-        private Entry(Builder builder) {
-            this.address = builder.address;
-            this.macAddress = builder.macAddress;
-            this.position = builder.position;
-            this.locationServicePending = builder.locationServicePending;
-            this.isNeighbour = builder.isNeighbour;
-            this.sequenceNumber = builder.sequenceNumber;
-            this.timestamp = builder.timestamp;
-        }
-
+     
         public Builder builder() { return new Builder(); }
 
         public static class Builder {

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/LongPositionVector.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/LongPositionVector.java
@@ -41,32 +41,21 @@ import org.threeten.bp.ZoneOffset;
  * Later it has to be encoded as an unsigned units of 0.1 degree from North.
  */
 public final class LongPositionVector {
+	
+	/** Long Position Vector length in bytes. */
+    public static final int LENGTH = 24;
 
-    @Override
-    public String toString() {
-        return "LPV[" + (address.isPresent() ? address.get() : "") + " " + timestamp
-                + " " + position + " PAI=" + isPositionConfident
-                + ", " + speedMetersPerSecond + " m/s, bearing "
-                + headingDegreesFromNorth + " degrees]";
-    }
-
-    private final Optional<Address>  address;
+    private final static double SPEED_STORE_SCALE   = 0.01;  // 0.01 meters per second.
+    private final static double HEADING_STORE_SCALE = 0.1;   // 0.1 degrees from north.
+    private static final long LEAP_SECONDS_SINCE_2004 = 4;  // Let's assume we're always in 2015.
+    
+	private final Optional<Address>  address;
     private final Instant            timestamp;
     private final Position           position;
     private final boolean            isPositionConfident;
     private final double             speedMetersPerSecond;
     private final double             headingDegreesFromNorth;
-
-    public Optional<Address> address()                 { return address; }
-    public Instant           timestamp()               { return timestamp; }
-    public Position          position()                { return position; }
-    public boolean           isPositionConfident()     { return isPositionConfident; }
-    public double            speedMetersPerSecond()    { return speedMetersPerSecond; }
-    public double            headingDegreesFromNorth() { return headingDegreesFromNorth; }
-
-
-    //private long taiMillisSince2004Mod32;
-
+    
     public LongPositionVector(
             Address  address,
             Instant  timestamp,
@@ -99,13 +88,25 @@ public final class LongPositionVector {
         this.headingDegreesFromNorth = headingDegreesFromNorth;
     }
 
-    /** Long Position Vector length in bytes. */
-    public static final int LENGTH = 24;
+    
+	@Override
+    public String toString() {
+        return "LPV[" + (address.isPresent() ? address.get() : "") + " " + timestamp
+                + " " + position + " PAI=" + isPositionConfident
+                + ", " + speedMetersPerSecond + " m/s, bearing "
+                + headingDegreesFromNorth + " degrees]";
+    }
+
+    public Optional<Address> address()                 { return address; }
+    public Instant           timestamp()               { return timestamp; }
+    public Position          position()                { return position; }
+    public boolean           isPositionConfident()     { return isPositionConfident; }
+    public double            speedMetersPerSecond()    { return speedMetersPerSecond; }
+    public double            headingDegreesFromNorth() { return headingDegreesFromNorth; }
 
 
-    private final static double SPEED_STORE_SCALE   = 0.01;  // 0.01 meters per second.
-    private final static double HEADING_STORE_SCALE = 0.1;   // 0.1 degrees from north.
-
+    
+  
     private int speedAsStoreUnit(double speedMetersPerSecond) {
         return (int) Math.round(speedMetersPerSecond / SPEED_STORE_SCALE);
     }
@@ -167,9 +168,9 @@ public final class LongPositionVector {
             headingDegreesFromNorth
             );
     }
-
-    private static final long LEAP_SECONDS_SINCE_2004 = 4;  // Let's assume we're always in 2015.
-
+    
+    //private long taiMillisSince2004Mod32;
+    
     /** Returns TAI milliseconds mod 2^32 for the given date.
      *
      * Since java int is signed 32 bit integer, return long instead.

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/MacAddress.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/MacAddress.java
@@ -11,11 +11,8 @@ import java.util.Arrays;
  * {@link #hashCode()}.
  */
 public final class MacAddress {
-    @Override public String toString() {
-        return "MacAddress[" + address + "]";
-    }
-
-    private final long address;
+	
+	private final long address;
 
     public MacAddress(long address) {
         if ((address & 0xffff_0000_0000_0000L) != 0) {
@@ -26,6 +23,10 @@ public final class MacAddress {
 
     public MacAddress(String str) {
         this(parseFromString(str));
+    }
+	
+    @Override public String toString() {
+        return "MacAddress[" + address + "]";
     }
 
     public long value() { return address; }

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/Position.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/Position.java
@@ -20,25 +20,24 @@ import java.nio.ByteBuffer;
  * 32 bit signed integer in [1/10 micro-degree] units.
  */
 public final class Position {
-    @Override
+	
+	final static double MICRODEGREE = 1E-6;
+	final static double STORE_UNIT = 0.1 * MICRODEGREE;
+	final static double earthRadius = 6371000; // In meters. In miles: 3958.75;
+    public static final int LENGTH = 2*4;  // Two 32-bit integers.
+
+	private final double lattitudeDegrees;
+	private final double longitudeDegrees;
+
+	public Position(double lattitudeDegrees, double longitudeDegrees) {
+	    this.lattitudeDegrees = lattitudeDegrees;
+	    this.longitudeDegrees = longitudeDegrees;
+	}
+	
+	@Override
     public String toString() {
         return "Pos(" + lattitudeDegrees + ", " + longitudeDegrees + ")";
     }
-
-    final static double MICRODEGREE = 1E-6;
-    final static double STORE_UNIT = 0.1 * MICRODEGREE;
-    final static double earthRadius = 6371000; // In meters. In miles: 3958.75;
-
-
-    private final double lattitudeDegrees;
-    private final double longitudeDegrees;
-
-    public Position(double lattitudeDegrees, double longitudeDegrees) {
-        this.lattitudeDegrees = lattitudeDegrees;
-        this.longitudeDegrees = longitudeDegrees;
-    }
-
-    public static final int LENGTH = 2*4;  // Two 32-bit integers.
 
     public double lattitudeDegrees() { return lattitudeDegrees; }
     public double longitudeDegrees() { return longitudeDegrees; }

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/ShortPositionVector.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/ShortPositionVector.java
@@ -5,14 +5,13 @@ import java.nio.ByteBuffer;
 import org.threeten.bp.Instant;
 
 public class ShortPositionVector {
-    private final Address   address;
+	 
+	private final Address   address;
     private final Instant   timestamp;
     private final Position  position;
-
-    public Address  address()   { return address; }
-    public Instant  timestamp() { return timestamp; }
-    public Position position()  { return position; }
-
+    /** Length in bytes. */
+    public static final int LENGTH = 20;
+    
     public ShortPositionVector(
             Address  address,
             Instant  timestamp,
@@ -22,9 +21,10 @@ public class ShortPositionVector {
         this.timestamp = timestamp;
         this.position  = position;
     }
-
-    /** Length in bytes. */
-    public static final int LENGTH = 20;
+    
+    public Address  address()   { return address; }
+    public Instant  timestamp() { return timestamp; }
+    public Position position()  { return position; }
 
     public static ShortPositionVector getFrom(ByteBuffer buffer) {
         Address  address   = Address.getFrom(buffer);

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/TrafficClass.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/TrafficClass.java
@@ -9,7 +9,13 @@ package net.gcdc.geonetworking;
  */
 public final class TrafficClass {
 
-    @Override
+	private final byte code;
+
+    public TrafficClass(byte code) {
+        this.code = code;
+    }
+	
+	@Override
     public String toString() {
         return "TrafficClass [0x" + Integer.toHexString(code) + "]";
     }
@@ -34,12 +40,6 @@ public final class TrafficClass {
         if (code != other.code)
             return false;
         return true;
-    }
-
-    private final byte code;
-
-    public TrafficClass(byte code) {
-        this.code = code;
     }
 
     public byte asByte() {

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/gpsdclient/GpsdClient.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/gpsdclient/GpsdClient.java
@@ -41,8 +41,12 @@ public class GpsdClient implements PositionProvider, AutoCloseable,TelnetNotific
     private final ExecutorService executor    = Executors.newSingleThreadExecutor();
     private final InetSocketAddress gpsdAddress;
     private Future<?>       runner;
-
     private static TelnetClient tc = null;
+    
+    public GpsdClient(InetSocketAddress address) throws IOException {
+        logger.info("Starting GPSd client");
+        gpsdAddress = address;
+    }
 
     @Override
     public void run(){
@@ -161,11 +165,6 @@ public class GpsdClient implements PositionProvider, AutoCloseable,TelnetNotific
              }
          });
     	 return runner;
-    }
-
-    public GpsdClient(InetSocketAddress address) throws IOException {
-        logger.info("Starting GPSd client");
-        gpsdAddress = address;
     }
 
     @Override

--- a/geonetworking/src/main/java/net/gcdc/plugtestcms4/DUT.java
+++ b/geonetworking/src/main/java/net/gcdc/plugtestcms4/DUT.java
@@ -5,18 +5,27 @@ import net.gcdc.plugtestcms4.ping.PingSettings;
 
 public class DUT
 {
+	private boolean active = false;
+	private String rootPassword = "voyage";
+	private String name = "Unset";
+	private String ipv4AddressEth = "Unset";
+	private String ipv4AddressWLAN = "Unset";
+	private boolean transmits = false;
+	private boolean receives = false;
+	private PingSettings pingSettings = null;
+	private Object pingSettingsLock = new Object ();
+	private int rxPort = 1236;
+	private int txPort = 1235;
 
-  public DUT (String name, String ipv4AddressEth, String ipv4AddressWLAN, int rxPort)
-  {
-    if (name == null || ipv4AddressEth == null || ipv4AddressWLAN == null)
-      throw new IllegalArgumentException ();
-    this.name = name;
-    this.ipv4AddressEth = ipv4AddressEth;
-    this.ipv4AddressWLAN = ipv4AddressWLAN;
-    this.rxPort = rxPort;
-  }
-
-  private boolean active = false;
+	public DUT (String name, String ipv4AddressEth, String ipv4AddressWLAN, int rxPort)
+	{
+		if (name == null || ipv4AddressEth == null || ipv4AddressWLAN == null)
+			throw new IllegalArgumentException ();
+		this.name = name;
+		this.ipv4AddressEth = ipv4AddressEth;
+		this.ipv4AddressWLAN = ipv4AddressWLAN;
+		this.rxPort = rxPort;
+	}
 
   public synchronized boolean getActive ()
   {
@@ -53,9 +62,7 @@ public class DUT
       }
     }
   }
-
-  private String name = "Unset";
-
+  
   public String getName ()
   {
     return this.name;
@@ -66,16 +73,12 @@ public class DUT
     if (name == null)
       throw new IllegalArgumentException ();
     this.name = name;
-  }
-
-  private String rootPassword = "voyage";
+  } 
 
   public final String getRootPassword ()
   {
     return this.rootPassword;
   }
-
-  private String ipv4AddressEth = "Unset";
 
   public String getIpv4AddressEth ()
   {
@@ -92,8 +95,6 @@ public class DUT
     }
   }
 
-  private String ipv4AddressWLAN = "Unset";
-
   public String getIpv4AddressWLAN ()
   {
     return this.ipv4AddressWLAN ;
@@ -109,8 +110,6 @@ public class DUT
     }
   }
 
-  private boolean receives = false;
-
   public boolean getReceives ()
   {
     return this.receives;
@@ -123,8 +122,6 @@ public class DUT
       this.receives = receives;
     }
   }
-
-  private int rxPort = 1236;
 
   public int getRxPort ()
   {
@@ -139,8 +136,6 @@ public class DUT
     }
   }
 
-  private boolean transmits = false;
-
   public boolean getTransmits ()
   {
     return this.transmits;
@@ -154,8 +149,6 @@ public class DUT
     }
   }
 
-  private int txPort = 1235;
-
   public int getTxPort ()
   {
     return this.txPort;
@@ -168,10 +161,6 @@ public class DUT
       this.txPort = txPort;
     }
   }
-
-  private PingSettings pingSettings = null;
-
-  private Object pingSettingsLock = new Object ();
 
   public PingStatus getPingStatus ()
   {
@@ -187,5 +176,4 @@ public class DUT
       return hostStatus[0];
     }
   }
-
 }

--- a/geonetworking/src/main/java/net/gcdc/plugtestcms4/ping/PingSettings.java
+++ b/geonetworking/src/main/java/net/gcdc/plugtestcms4/ping/PingSettings.java
@@ -8,62 +8,67 @@ import java.util.Map;
 
 public class PingSettings
 {
+	private boolean active = false;
+	private Thread pingStatusThread = null;
+	private int pollInterval_ms = 10000;
+	private int timeout_ms = 50;
+	private boolean useExternalPing = false;
+	private String[] hostAddressesToMonitor = new String[] { };
+	private final Map<String, Boolean> hostAddressStatus = new HashMap<> ();
+	  
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//
+	// PROPERTY CHANGE SUPPORT
+	//
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   
-  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  //
-  // PROPERTY CHANGE SUPPORT
-  //
-  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	protected final PropertyChangeSupport pcs = new PropertyChangeSupport (this);
+
+	public void addPropertyChangeListener (PropertyChangeListener listener)
+	{
+		this.pcs.addPropertyChangeListener (listener);
+	}
+
+	public void removePropertyChangeListener (PropertyChangeListener listener)
+	{
+		this.pcs.removePropertyChangeListener (listener);
+	}
+
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	//
+	// PROPERTY active
+	//
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+	public final synchronized boolean getActive ()
+	{
+		return this.active;
+	}
   
-  protected final PropertyChangeSupport pcs = new PropertyChangeSupport (this);
-
-  public void addPropertyChangeListener (PropertyChangeListener listener)
-  {
-    this.pcs.addPropertyChangeListener (listener);
-  }
-
-  public void removePropertyChangeListener (PropertyChangeListener listener)
-  {
-    this.pcs.removePropertyChangeListener (listener);
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  //
-  // PROPERTY active
-  //
-  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-  private boolean active = false;
-  
-  public final synchronized boolean getActive ()
-  {
-    return this.active;
-  }
-  
-  public final /* synchronized */ void setActive (boolean active)
-  {
-    boolean fireEvent = false;
-    synchronized (this)
-    {
-      if (active != this.active)
-      {
-        fireEvent = true;
-        if (this.pingStatusThread != null)
-        {
-          this.pingStatusThread.interrupt ();
-          this.pingStatusThread = null;
-        }
-        this.active = active;
-        if (this.active)
-        {
-          this.pingStatusThread = new PingStatusThread (this);
-          this.pingStatusThread.start ();
-        }
-      }
+	public final /* synchronized */ void setActive (boolean active)
+	{
+		boolean fireEvent = false;
+		synchronized (this)
+		{
+			if (active != this.active)
+			{
+				fireEvent = true;
+				if (this.pingStatusThread != null)
+				{
+					this.pingStatusThread.interrupt ();
+					this.pingStatusThread = null;
+				}
+				this.active = active;
+				if (this.active)
+				{
+					this.pingStatusThread = new PingStatusThread (this);
+					this.pingStatusThread.start ();
+				}
+		 }
     }
-    if (fireEvent)
+     if (fireEvent)
       this.pcs.firePropertyChange ("active", ! this.active, this.active);
-  }
+    }
   
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   //
@@ -71,7 +76,6 @@ public class PingSettings
   //
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  private Thread pingStatusThread = null;
   
   public final synchronized Thread getPingStatusThread ()
   {
@@ -84,7 +88,7 @@ public class PingSettings
   //
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  private int pollInterval_ms = 10000;
+ 
   
   public final synchronized int getPollInterval_ms ()
   {
@@ -109,7 +113,7 @@ public class PingSettings
   //
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  private int timeout_ms = 50;
+  
   
   public final synchronized int getTimeout_ms ()
   {
@@ -133,8 +137,6 @@ public class PingSettings
   // PROPERTY useExternalPing
   //
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-  private boolean useExternalPing = false;
   
   public final boolean getUseExternalPing ()
   {
@@ -155,8 +157,6 @@ public class PingSettings
   // PROPERTY hostAddressesToMonitor
   //
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-  private String[] hostAddressesToMonitor = new String[] { };
 
   public final synchronized String[] getHostAddressesToMonitor ()
   {
@@ -186,8 +186,6 @@ public class PingSettings
   //
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  private final Map<String, Boolean> hostAddressStatus = new HashMap<> ();
-  
   public final synchronized PingStatus[] getHostStatus ()
   {
     final PingStatus[] hostStatus = new PingStatus[this.hostAddressesToMonitor.length];

--- a/uppertester/src/main/java/net/gcdc/uppertester/Initialize.java
+++ b/uppertester/src/main/java/net/gcdc/uppertester/Initialize.java
@@ -1,9 +1,11 @@
 package net.gcdc.uppertester;
 
 public class Initialize {
-    @Override public String toString() {
+	
+	byte messageType = 0x00;
+    long hashedId8;
+    
+	@Override public String toString() {
         return "Initialize [messageType=" + messageType + ", hashedId8=" + hashedId8 + "]";
     }
-    byte messageType = 0x00;
-    long hashedId8;
 }

--- a/uppertester/src/main/java/net/gcdc/uppertester/InitializeResult.java
+++ b/uppertester/src/main/java/net/gcdc/uppertester/InitializeResult.java
@@ -1,16 +1,17 @@
 package net.gcdc.uppertester;
 
 public class InitializeResult implements Response {
-    @Override public String toString() {
-        return "InitializeResult [messageType=" + messageType + ", result=" + result + "]";
-    }
+   
+	byte messageType = 0x01;
+    byte result;
 
     public InitializeResult() {}
 
     public InitializeResult(byte result) {
         this.result = result;
     }
-
-    byte messageType = 0x01;
-    byte result;
+    
+	@Override public String toString() {
+        return "InitializeResult [messageType=" + messageType + ", result=" + result + "]";
+    }
 }

--- a/uppertester/src/main/java/net/gcdc/uppertester/Parser.java
+++ b/uppertester/src/main/java/net/gcdc/uppertester/Parser.java
@@ -59,13 +59,16 @@ public class Parser {
             );
 
     private final List<Class<?>> allMessages = new ArrayList<>(staticMessages);
+    private final Map<Byte, Class<?>> msgToId = new HashMap<>();
+    
+    public Parser() {
+        refreshMessageMap();
+    }
 
     void registerMessage(Class<?> message) {
         allMessages.add(message);
         refreshMessageMap();
     }
-
-    private final Map<Byte, Class<?>> msgToId = new HashMap<>();
 
     private void refreshMessageMap() {
         msgToId.clear();
@@ -88,10 +91,7 @@ public class Parser {
         }
     }
 
-    public Parser() {
-        refreshMessageMap();
-    }
-
+   
     public Object parse2(byte[] b) throws InstantiationException, IllegalAccessException {
         byte msgType = b[0];
         return parse(ByteBuffer.wrap(b), msgToId.get(msgType));

--- a/vehicle-adapter/src/main/java/net/gcdc/vehicle/LocalIclcm.java
+++ b/vehicle-adapter/src/main/java/net/gcdc/vehicle/LocalIclcm.java
@@ -161,23 +161,6 @@ public class LocalIclcm{
         if(!checkInt(Intention.class, intention, "Intention")){ throw new IllegalArgumentException(); }
         if(!checkInt(Counter.class, counter, "Counter")){ counter = 0; }
     }
-
-    /* Return true if the local CAM has a low frequency container. */
-    boolean hasLowFrequencyContainer(){
-        return (containerMask & (1<<7)) != 0;
-    }
-
-    boolean hasParticipantsReady(){
-        return (lowFrequencyMask & (1<<7)) != 0;
-    }
-
-    boolean hasStartPlatoon(){
-        return (lowFrequencyMask & (1<<6)) != 0;
-    }
-
-    boolean hasEndOfScenario(){
-        return (lowFrequencyMask & (1<<5)) != 0;
-    }    
     
     /* For creating a local iCLCM from a iCLCM message as received from another ITS station. */
     LocalIclcm(IgameCooperativeLaneChangeMessage iCLCM){
@@ -258,6 +241,22 @@ public class LocalIclcm{
         counter = (int) scenarioObject.getCounterIntersection().value;      
     }
 
+    /* Return true if the local CAM has a low frequency container. */
+    boolean hasLowFrequencyContainer(){
+        return (containerMask & (1<<7)) != 0;
+    }
+
+    boolean hasParticipantsReady(){
+        return (lowFrequencyMask & (1<<7)) != 0;
+    }
+
+    boolean hasStartPlatoon(){
+        return (lowFrequencyMask & (1<<6)) != 0;
+    }
+
+    boolean hasEndOfScenario(){
+        return (lowFrequencyMask & (1<<5)) != 0;
+    }    
 
     /* Return the IntRange min and max value as a nice string. */
     String getIntRangeString(IntRange intRange){


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1213 - “  Members of classes and interfaces should be in a predefined orderl”. 
 You can find more information about the issue here: 
This PR will remove 400 min TD.
 https://dev.eclipse.org/sonar/rules/show/squid:S1213
 Please let me know if you have any questions.
Fevzi Ozgul