### PR TITLE
Fixing squid: S1213 The members of an interface declaration or class should appear in a pre-defined order" Part 4

### DIFF
--- a/geonetworking/src/main/java/net/gcdc/geonetworking/LongPositionVector.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/LongPositionVector.java
@@ -41,32 +41,21 @@ import org.threeten.bp.ZoneOffset;
  * Later it has to be encoded as an unsigned units of 0.1 degree from North.
  */
 public final class LongPositionVector {
-
-    @Override
-    public String toString() {
-        return "LPV[" + (address.isPresent() ? address.get() : "") + " " + timestamp
-                + " " + position + " PAI=" + isPositionConfident
-                + ", " + speedMetersPerSecond + " m/s, bearing "
-                + headingDegreesFromNorth + " degrees]";
-    }
-
-    private final Optional<Address>  address;
+	
+	private final Optional<Address>  address;
     private final Instant            timestamp;
     private final Position           position;
     private final boolean            isPositionConfident;
     private final double             speedMetersPerSecond;
     private final double             headingDegreesFromNorth;
 
-    public Optional<Address> address()                 { return address; }
-    public Instant           timestamp()               { return timestamp; }
-    public Position          position()                { return position; }
-    public boolean           isPositionConfident()     { return isPositionConfident; }
-    public double            speedMetersPerSecond()    { return speedMetersPerSecond; }
-    public double            headingDegreesFromNorth() { return headingDegreesFromNorth; }
+    /** Long Position Vector length in bytes. */
+    public static final int LENGTH = 24;
+    private final static double SPEED_STORE_SCALE   = 0.01;  // 0.01 meters per second.
+    private final static double HEADING_STORE_SCALE = 0.1;   // 0.1 degrees from north.
+    private static final long LEAP_SECONDS_SINCE_2004 = 4;  // Let's assume we're always in 2015.
 
-
-    //private long taiMillisSince2004Mod32;
-
+  //private long taiMillisSince2004Mod32;
     public LongPositionVector(
             Address  address,
             Instant  timestamp,
@@ -99,13 +88,23 @@ public final class LongPositionVector {
         this.headingDegreesFromNorth = headingDegreesFromNorth;
     }
 
-    /** Long Position Vector length in bytes. */
-    public static final int LENGTH = 24;
+    @Override
+    public String toString() {
+        return "LPV[" + (address.isPresent() ? address.get() : "") + " " + timestamp
+                + " " + position + " PAI=" + isPositionConfident
+                + ", " + speedMetersPerSecond + " m/s, bearing "
+                + headingDegreesFromNorth + " degrees]";
+    }
 
+    
 
-    private final static double SPEED_STORE_SCALE   = 0.01;  // 0.01 meters per second.
-    private final static double HEADING_STORE_SCALE = 0.1;   // 0.1 degrees from north.
-
+    public Optional<Address> address()                 { return address; }
+    public Instant           timestamp()               { return timestamp; }
+    public Position          position()                { return position; }
+    public boolean           isPositionConfident()     { return isPositionConfident; }
+    public double            speedMetersPerSecond()    { return speedMetersPerSecond; }
+    public double            headingDegreesFromNorth() { return headingDegreesFromNorth; }
+   
     private int speedAsStoreUnit(double speedMetersPerSecond) {
         return (int) Math.round(speedMetersPerSecond / SPEED_STORE_SCALE);
     }
@@ -168,8 +167,7 @@ public final class LongPositionVector {
             );
     }
 
-    private static final long LEAP_SECONDS_SINCE_2004 = 4;  // Let's assume we're always in 2015.
-
+    
     /** Returns TAI milliseconds mod 2^32 for the given date.
      *
      * Since java int is signed 32 bit integer, return long instead.

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/MacAddress.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/MacAddress.java
@@ -11,11 +11,8 @@ import java.util.Arrays;
  * {@link #hashCode()}.
  */
 public final class MacAddress {
-    @Override public String toString() {
-        return "MacAddress[" + address + "]";
-    }
-
-    private final long address;
+    
+	private final long address;
 
     public MacAddress(long address) {
         if ((address & 0xffff_0000_0000_0000L) != 0) {
@@ -28,6 +25,11 @@ public final class MacAddress {
         this(parseFromString(str));
     }
 
+	@Override public String toString() {
+        return "MacAddress[" + address + "]";
+    }
+
+    
     public long value() { return address; }
 
     /** Returns 6-bytes array representing this address. */

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/Position.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/Position.java
@@ -20,26 +20,25 @@ import java.nio.ByteBuffer;
  * 32 bit signed integer in [1/10 micro-degree] units.
  */
 public final class Position {
-    @Override
+	
+	final static double MICRODEGREE = 1E-6;
+	final static double STORE_UNIT = 0.1 * MICRODEGREE;
+	final static double earthRadius = 6371000; // In meters. In miles: 3958.75;
+	public static final int LENGTH = 2*4;  // Two 32-bit integers.
+
+	private final double lattitudeDegrees;
+	private final double longitudeDegrees;
+
+	public Position(double lattitudeDegrees, double longitudeDegrees) {
+	    this.lattitudeDegrees = lattitudeDegrees;
+	    this.longitudeDegrees = longitudeDegrees;
+	}
+	
+	@Override
     public String toString() {
         return "Pos(" + lattitudeDegrees + ", " + longitudeDegrees + ")";
     }
-
-    final static double MICRODEGREE = 1E-6;
-    final static double STORE_UNIT = 0.1 * MICRODEGREE;
-    final static double earthRadius = 6371000; // In meters. In miles: 3958.75;
-
-
-    private final double lattitudeDegrees;
-    private final double longitudeDegrees;
-
-    public Position(double lattitudeDegrees, double longitudeDegrees) {
-        this.lattitudeDegrees = lattitudeDegrees;
-        this.longitudeDegrees = longitudeDegrees;
-    }
-
-    public static final int LENGTH = 2*4;  // Two 32-bit integers.
-
+    
     public double lattitudeDegrees() { return lattitudeDegrees; }
     public double longitudeDegrees() { return longitudeDegrees; }
 

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/ShortPositionVector.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/ShortPositionVector.java
@@ -8,11 +8,9 @@ public class ShortPositionVector {
     private final Address   address;
     private final Instant   timestamp;
     private final Position  position;
-
-    public Address  address()   { return address; }
-    public Instant  timestamp() { return timestamp; }
-    public Position position()  { return position; }
-
+    /** Length in bytes. */
+    public static final int LENGTH = 20;
+    
     public ShortPositionVector(
             Address  address,
             Instant  timestamp,
@@ -23,8 +21,9 @@ public class ShortPositionVector {
         this.position  = position;
     }
 
-    /** Length in bytes. */
-    public static final int LENGTH = 20;
+    public Address  address()   { return address; }
+    public Instant  timestamp() { return timestamp; }
+    public Position position()  { return position; }
 
     public static ShortPositionVector getFrom(ByteBuffer buffer) {
         Address  address   = Address.getFrom(buffer);

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/TrafficClass.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/TrafficClass.java
@@ -9,6 +9,12 @@ package net.gcdc.geonetworking;
  */
 public final class TrafficClass {
 
+    private final byte code;
+    
+    public TrafficClass(byte code) {
+        this.code = code;
+    }
+    
     @Override
     public String toString() {
         return "TrafficClass [0x" + Integer.toHexString(code) + "]";
@@ -36,11 +42,7 @@ public final class TrafficClass {
         return true;
     }
 
-    private final byte code;
-
-    public TrafficClass(byte code) {
-        this.code = code;
-    }
+    
 
     public byte asByte() {
         return code;

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/gpsdclient/GpsdClient.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/gpsdclient/GpsdClient.java
@@ -43,6 +43,11 @@ public class GpsdClient implements PositionProvider, AutoCloseable,TelnetNotific
     private Future<?>       runner;
 
     private static TelnetClient tc = null;
+    
+    public GpsdClient(InetSocketAddress address) throws IOException {
+        logger.info("Starting GPSd client");
+        gpsdAddress = address;
+    }
 
     @Override
     public void run(){
@@ -163,11 +168,7 @@ public class GpsdClient implements PositionProvider, AutoCloseable,TelnetNotific
     	 return runner;
     }
 
-    public GpsdClient(InetSocketAddress address) throws IOException {
-        logger.info("Starting GPSd client");
-        gpsdAddress = address;
-    }
-
+    
     @Override
     public LongPositionVector getLatestPosition() {
         Optional<Address> emptyAddress = Optional.empty();

--- a/geonetworking/src/main/java/net/gcdc/plugtestcms4/DUT.java
+++ b/geonetworking/src/main/java/net/gcdc/plugtestcms4/DUT.java
@@ -5,7 +5,18 @@ import net.gcdc.plugtestcms4.ping.PingSettings;
 
 public class DUT
 {
-
+	private boolean active = false;
+	private String name = "Unset";
+	private String rootPassword = "voyage";
+	private String ipv4AddressEth = "Unset";
+	private String ipv4AddressWLAN = "Unset";
+	private boolean receives = false;
+	private int rxPort = 1236;
+	private boolean transmits = false;
+	private int txPort = 1235;
+	private PingSettings pingSettings = null;
+	private Object pingSettingsLock = new Object ();
+	 
   public DUT (String name, String ipv4AddressEth, String ipv4AddressWLAN, int rxPort)
   {
     if (name == null || ipv4AddressEth == null || ipv4AddressWLAN == null)
@@ -16,7 +27,6 @@ public class DUT
     this.rxPort = rxPort;
   }
 
-  private boolean active = false;
 
   public synchronized boolean getActive ()
   {
@@ -54,8 +64,6 @@ public class DUT
     }
   }
 
-  private String name = "Unset";
-
   public String getName ()
   {
     return this.name;
@@ -68,14 +76,12 @@ public class DUT
     this.name = name;
   }
 
-  private String rootPassword = "voyage";
 
   public final String getRootPassword ()
   {
     return this.rootPassword;
   }
 
-  private String ipv4AddressEth = "Unset";
 
   public String getIpv4AddressEth ()
   {
@@ -92,7 +98,6 @@ public class DUT
     }
   }
 
-  private String ipv4AddressWLAN = "Unset";
 
   public String getIpv4AddressWLAN ()
   {
@@ -109,8 +114,6 @@ public class DUT
     }
   }
 
-  private boolean receives = false;
-
   public boolean getReceives ()
   {
     return this.receives;
@@ -124,7 +127,6 @@ public class DUT
     }
   }
 
-  private int rxPort = 1236;
 
   public int getRxPort ()
   {
@@ -139,8 +141,7 @@ public class DUT
     }
   }
 
-  private boolean transmits = false;
-
+ 
   public boolean getTransmits ()
   {
     return this.transmits;
@@ -154,7 +155,6 @@ public class DUT
     }
   }
 
-  private int txPort = 1235;
 
   public int getTxPort ()
   {
@@ -169,9 +169,6 @@ public class DUT
     }
   }
 
-  private PingSettings pingSettings = null;
-
-  private Object pingSettingsLock = new Object ();
 
   public PingStatus getPingStatus ()
   {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 - “The members of an interface declaration or class should appear in a pre-defined order".
This PR will remove 150 min TD. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S106
Please let me know if you have any questions.
Fevzi Ozgul