### PR TITLE
Fixing squid  S1213 Members of classes and interfaces should appear in a predifend order part 3

### DIFF
--- a/camdenm/src/main/java/net/gcdc/camdenm/Iclcm.java
+++ b/camdenm/src/main/java/net/gcdc/camdenm/Iclcm.java
@@ -160,9 +160,6 @@ public class Iclcm {
 			this(new VehicleRearAxleLocation(),new ControllerType(), 
 					new VehicleResponseTime(), new TargetLongitudonalAcceleration(), new TimeHeadway(), new CruiseSpeed());
 		}
-		@Override public String toString() { return "VehicleContainerHighFrequency(" + vehicleRearAxleLocation + ", " 
-				+ controllerType + ", " + vehicleResponseTime + ", " + targetLongitudinalAcceleration + ", " 
-						+ timeHeadway + ", " + cruisespeed + ")"; }
 		
 		public VehicleContainerHighFrequency(VehicleRearAxleLocation vehicleRearAxleLocation,ControllerType controllerType,
 				VehicleResponseTime vehicleResponseTime,TargetLongitudonalAcceleration targetLongitudinalAcceleration,
@@ -174,7 +171,11 @@ public class Iclcm {
 			this.timeHeadway = timeHeadway;
 			this.cruisespeed = cruisespeed;
 		}
-
+		
+		@Override public String toString() { return "VehicleContainerHighFrequency(" + vehicleRearAxleLocation + ", " 
+				+ controllerType + ", " + vehicleResponseTime + ", " + targetLongitudinalAcceleration + ", " 
+						+ timeHeadway + ", " + cruisespeed + ")"; }
+		
 		public VehicleRearAxleLocation getVehicleRearAxleLocation() {
 			return vehicleRearAxleLocation;
 		}

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/Area.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/Area.java
@@ -11,17 +11,27 @@ import java.nio.ByteBuffer;
  */
 public final class Area {
 
-    @Override public String toString() {
-        return "Area [center=" + center + ", distanceAmeters=" + distanceAmeters
-                + ", distanceBmeters=" + distanceBmeters + ", angleDegreesFromNorth="
-                + angleDegreesFromNorth + ", type=" + type + "]";
-    }
 
     private final Position center;
     private final double   distanceAmeters;
     private final double   distanceBmeters;
     private final double   angleDegreesFromNorth;
     private final Type     type;
+
+
+    private Area(Position center, double distanceA, double distanceB, double angleDegreesFromNorth, Type type) {
+        this.center    = center;
+        this.distanceAmeters = distanceA;
+        this.distanceBmeters = distanceB;
+        this.angleDegreesFromNorth = angleDegreesFromNorth;
+        this.type = type;
+    }
+    
+	@Override public String toString() {
+        return "Area [center=" + center + ", distanceAmeters=" + distanceAmeters
+                + ", distanceBmeters=" + distanceBmeters + ", angleDegreesFromNorth="
+                + angleDegreesFromNorth + ", type=" + type + "]";
+    }
 
     @Override
     public int hashCode() {
@@ -73,15 +83,6 @@ public final class Area {
             for (Area.Type h: Area.Type.values()) { if (h.code() == code) { return h; } }
             throw new IllegalArgumentException("Can't recognize area type: " + code);
         }
-    }
-
-
-    private Area(Position center, double distanceA, double distanceB, double angleDegreesFromNorth, Type type) {
-        this.center    = center;
-        this.distanceAmeters = distanceA;
-        this.distanceBmeters = distanceB;
-        this.angleDegreesFromNorth = angleDegreesFromNorth;
-        this.type = type;
     }
 
     public static Area getFrom(ByteBuffer buffer, Area.Type type) {

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/BasicHeader.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/BasicHeader.java
@@ -11,6 +11,19 @@ public class BasicHeader {
                                                 // octet 1 (reserved)
     private final Lifetime   lifetime;          // octet 2
     private final byte       remainingHopLimit; // octet 3
+    
+    public BasicHeader(
+            byte version,
+            NextHeader nextHeader,
+            Lifetime lifetime,
+            byte remainingHopLimit
+            ) {
+        this.version              = version;
+        this.nextHeader           = nextHeader;
+        this.lifetime             = lifetime;
+        this.remainingHopLimit    = remainingHopLimit;
+    }
+
 
     public byte       version()           { return version;           }
     public NextHeader nextHeader()        { return nextHeader;        }
@@ -126,18 +139,6 @@ public class BasicHeader {
             return (byte) (multiplier << 2 | base.code());
         }
 
-    }
-
-    public BasicHeader(
-            byte version,
-            NextHeader nextHeader,
-            Lifetime lifetime,
-            byte remainingHopLimit
-            ) {
-        this.version              = version;
-        this.nextHeader           = nextHeader;
-        this.lifetime             = lifetime;
-        this.remainingHopLimit    = remainingHopLimit;
     }
 
     public ByteBuffer putTo(ByteBuffer buffer) {

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/BtpPacket.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/BtpPacket.java
@@ -15,6 +15,8 @@ public class BtpPacket {
 
     private byte[] gnPayload = null;
 
+    public static final int HEADER_LENGTH = 4;
+
     private BtpPacket(
             Optional<Short>              sourcePort,
             short                        destinationPort,
@@ -133,8 +135,6 @@ public class BtpPacket {
         }
         return gnPayload;
     }
-
-    public static final int HEADER_LENGTH = 4;
 
     private ByteBuffer putHeaderTo(ByteBuffer buffer) {
         return buffer.putShort(destinationPort)

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/CommonHeader.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/CommonHeader.java
@@ -12,14 +12,7 @@ public final class CommonHeader {
 
     /** Header length in bytes. */
     public static final int LENGTH = 8;
-
-    public UpperProtocolType nextHeader()      { return nextHeader;      }
-    public DestinationType   typeAndSubtype()  { return typeAndSubtype;  }
-    public TrafficClass      trafficClass()    { return trafficClass;    }
-    public boolean           isMobile()        { return isMobile;        }
-    public short             payloadLength()   { return payloadLength;   }
-    public byte              maximumHopLimit() { return maximumHopLimit; }
-
+    
     public CommonHeader(
             UpperProtocolType nextHeader,
             DestinationType   typeAndSubtype,
@@ -35,6 +28,15 @@ public final class CommonHeader {
         this.payloadLength   = payloadLength;
         this.maximumHopLimit = maximumHopLimit;
     }
+
+    public UpperProtocolType nextHeader()      { return nextHeader;      }
+    public DestinationType   typeAndSubtype()  { return typeAndSubtype;  }
+    public TrafficClass      trafficClass()    { return trafficClass;    }
+    public boolean           isMobile()        { return isMobile;        }
+    public short             payloadLength()   { return payloadLength;   }
+    public byte              maximumHopLimit() { return maximumHopLimit; }
+
+   
 
     public ByteBuffer putTo(ByteBuffer buffer) {
         byte  nextHeaderAndReserved = (byte) (nextHeader.value() << 4);

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/Destination.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/Destination.java
@@ -7,7 +7,7 @@ public abstract class Destination {
     public abstract Optional<Double> maxLifetimeSeconds();
     public abstract Optional<Byte>   maxHopLimit();
     public abstract Optional<Byte>   remainingHopLimit();
-
+    
     public static final class SingleHop extends Destination {
         private final Optional<Double> maxLifetimeSeconds;
 
@@ -43,7 +43,28 @@ public abstract class Destination {
     }
 
     public static final class Geobroadcast extends Destination {
-        @Override
+        
+    	final private Area              area;
+        final private Optional<Double>  maxLifetimeSeconds;
+        final private Optional<Byte>    maxHopLimit;
+        final private Optional<Byte>    remainingHopLimit;
+        final private boolean           isAnycast;
+
+        private Geobroadcast (
+                Area              area,
+                Optional<Double>  maxLifetimeSeconds,
+                Optional<Byte>    maxHopLimit,
+                Optional<Byte>    remainingHopLimit,
+                boolean           isAnycast
+                ) {
+            this.area               = area;
+            this.maxLifetimeSeconds = maxLifetimeSeconds;
+            this.maxHopLimit        = maxHopLimit;
+            this.remainingHopLimit  = remainingHopLimit;
+            this.isAnycast          = isAnycast;
+        }
+
+    	@Override
         public int hashCode() {
             final int prime = 31;
             int result = 1;
@@ -89,25 +110,6 @@ public abstract class Destination {
             } else if (!remainingHopLimit.equals(other.remainingHopLimit))
                 return false;
             return true;
-        }
-        final private Area              area;
-        final private Optional<Double>  maxLifetimeSeconds;
-        final private Optional<Byte>    maxHopLimit;
-        final private Optional<Byte>    remainingHopLimit;
-        final private boolean           isAnycast;
-
-        private Geobroadcast (
-                Area              area,
-                Optional<Double>  maxLifetimeSeconds,
-                Optional<Byte>    maxHopLimit,
-                Optional<Byte>    remainingHopLimit,
-                boolean           isAnycast
-                ) {
-            this.area               = area;
-            this.maxLifetimeSeconds = maxLifetimeSeconds;
-            this.maxHopLimit        = maxHopLimit;
-            this.remainingHopLimit  = remainingHopLimit;
-            this.isAnycast          = isAnycast;
         }
 
         public Area area() { return area; }

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/LocationTable.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/LocationTable.java
@@ -51,6 +51,17 @@ public class LocationTable {
         private final boolean isNeighbour;
         private final int sequenceNumber;
         private final Instant timestamp;
+        
+        private Entry(Builder builder) {
+            this.address = builder.address;
+            this.macAddress = builder.macAddress;
+            this.position = builder.position;
+            this.locationServicePending = builder.locationServicePending;
+            this.isNeighbour = builder.isNeighbour;
+            this.sequenceNumber = builder.sequenceNumber;
+            this.timestamp = builder.timestamp;
+        }
+
 
         public Address address() { return address; }
         public MacAddress macAddress() { return macAddress; }
@@ -65,16 +76,7 @@ public class LocationTable {
         public Entry withIsNeighbour(boolean isNeighbour) { return new Builder(this).isNeighbour(isNeighbour).create(); }
         public Entry withTimestamp(Instant timestamp) { return new Builder(this).timestamp(timestamp).create(); }
 
-        private Entry(Builder builder) {
-            this.address = builder.address;
-            this.macAddress = builder.macAddress;
-            this.position = builder.position;
-            this.locationServicePending = builder.locationServicePending;
-            this.isNeighbour = builder.isNeighbour;
-            this.sequenceNumber = builder.sequenceNumber;
-            this.timestamp = builder.timestamp;
-        }
-
+        
         public Builder builder() { return new Builder(); }
 
         public static class Builder {


### PR DESCRIPTION
"This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 - “The members of an interface declaration or class should appear in a pre-defined order".
This PR will remove 90 min TD. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S106
Please let me know if you have any questions.
Fevzi Ozgul