### PR TITLE
Fixing squid: S1118 Utility classes should not have public constructors

### DIFF
--- a/asn1-uper/src/main/java/net/gcdc/asn1/uper/UperEncoder.java
+++ b/asn1-uper/src/main/java/net/gcdc/asn1/uper/UperEncoder.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  *      TODO: Cover the rest of (useful) ASN.1 datatypes and PER-visible constraints,
  *      write unit tests for them. Clean-up, do more refactoring.
  **/
-public class UperEncoder {
+public final class UperEncoder {
     final static Logger logger = LoggerFactory.getLogger(UperEncoder.class);
 
     private final static int NUM_16K = 16384;
@@ -39,6 +39,8 @@ public class UperEncoder {
     private final static int NUM_48K = 49152;
     @SuppressWarnings("unused")
     private final static int NUM_64K = 65536;
+    
+    private UperEncoder(){}
 
     public static <T> byte[] encode(T obj)
             throws IllegalArgumentException, UnsupportedOperationException {

--- a/camdenm/src/main/java/net/gcdc/camdenm/Iclcm.java
+++ b/camdenm/src/main/java/net/gcdc/camdenm/Iclcm.java
@@ -36,11 +36,12 @@ import net.gcdc.camdenm.CoopIts.ItsPduHeader.ProtocolVersion;
  * under grant agreement no 612035.
  *
  */
-public class Iclcm {
+public final  class Iclcm {
 	/**
 	 * MessageID of i-GAME cooperative lane change message
 	 */
 	public static final int MessageID_iCLCM = 10;
+	private Iclcm(){}
 	
 	@Sequence
     public static class IgameCooperativeLaneChangeMessage {

--- a/geonetworking/src/main/java/net/gcdc/BtpStdinClient.java
+++ b/geonetworking/src/main/java/net/gcdc/BtpStdinClient.java
@@ -23,11 +23,13 @@ import net.gcdc.geonetworking.gpsdclient.GpsdClient;
 
 import org.threeten.bp.Instant;
 
-public class BtpStdinClient {
+public final class BtpStdinClient {
 
     private final static String usage =
             "Usage: java -cp gn.jar StdinClient --local-port <local-port> --remote-address <udp-to-ethernet-remote-host-and-port> <--has-ethernet-header | --no-ethernet-header> <--position <lat>,<lon> | --gpsd-server <host>:<port>> --btp-destination-port <port>" + "\n" +
     "BTP ports: 2001 (CAM), 2002 (DENM), 2003 (MAP), 2004 (SPAT).";
+    
+    private BtpStdinClient(){}
 
     public static void main(String[] args) throws IOException {
         if (args.length < 7) {

--- a/geonetworking/src/main/java/net/gcdc/BtpUdpClient.java
+++ b/geonetworking/src/main/java/net/gcdc/BtpUdpClient.java
@@ -30,13 +30,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.threeten.bp.Instant;
 
-public class BtpUdpClient {
+public final  class BtpUdpClient {
 
     private final static Logger logger = LoggerFactory.getLogger(BtpUdpClient.class);
 
     private final static String usage =
             "Usage: java -cp gn.jar BtpClient --local-udp2eth-port <local-port> --remote-udp2eth-address <udp-to-ethernet-remote-host-and-port> --local-data-port <port> --remote-data-address <host:port> --gpsd-server <host:port> --mac-address <xx:xx:xx:xx:xx:xx>" + "\n" +
     "BTP ports: 2001 (CAM), 2002 (DENM), 2003 (MAP), 2004 (SPAT).";
+    
+    private BtpUdpClient(){}
 
     public static void main(String[] args) throws IOException {
         if (args.length < 7) {

--- a/geonetworking/src/main/java/net/gcdc/UdpDuplicatorRunner.java
+++ b/geonetworking/src/main/java/net/gcdc/UdpDuplicatorRunner.java
@@ -6,7 +6,9 @@ import java.io.InputStreamReader;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
-public class UdpDuplicatorRunner {
+public final class UdpDuplicatorRunner {
+	
+	private UdpDuplicatorRunner(){}
 
     public static void main(String[] args) throws IOException {
         UdpDuplicator d = new UdpDuplicator();

--- a/geonetworking/src/main/java/net/gcdc/plugtestcms4/ping/Log.java
+++ b/geonetworking/src/main/java/net/gcdc/plugtestcms4/ping/Log.java
@@ -18,10 +18,11 @@ import java.util.logging.Logger;
  * @author Jan de Jongh
  * 
  */
-public class Log
+public final class Log
 {
 
   static Logger LOGGER = Logger.getLogger (Logger.GLOBAL_LOGGER_NAME);
+  private Log(){}
   
   /** Set the {@link Logger} for errors and warnings from this package.
    *


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1118 - “Utility classes should not have public constructors ”.
This PR will reduce 210 min of TD. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1118
 Please let me know if you have any questions.
Fevzi Ozgul