### PR TITLE
Fixing squid: S1192 String literals should not be duplicated

### DIFF
--- a/asn1-uper/src/main/java/net/gcdc/asn1/uper/SequenceCoder.java
+++ b/asn1-uper/src/main/java/net/gcdc/asn1/uper/SequenceCoder.java
@@ -10,6 +10,9 @@ import net.gcdc.asn1.uper.UperEncoder.Asn1ContainerFieldSorter;
 
 class SequenceCoder implements Decoder, Encoder {
 
+    private static final String ABSENT = "absent";
+    private static final String PRESENT = "present";
+
     @Override public <T> boolean canEncode(T obj, Annotation[] extraAnnotations) {
         Class<?> type = obj.getClass();
         AnnotationStore annotations = new AnnotationStore(type.getAnnotations(),
@@ -35,7 +38,7 @@ class SequenceCoder implements Decoder, Encoder {
             for (Field f : sorter.optionalOrdinaryFields) {
                 boolean fieldPresent = f.get(obj) != null;
                 UperEncoder.logger.debug("with optional field {} {}, presence encoded as bit <{}>",
-                        f.getName(), fieldPresent ? "present" : "absent", fieldPresent);
+                        f.getName(), fieldPresent ? PRESENT : ABSENT, fieldPresent);
                 bitbuffer.put(fieldPresent);  // null means the field is absent.
             }
             // All ordinary fields (fields within extension root).
@@ -64,7 +67,7 @@ class SequenceCoder implements Decoder, Encoder {
                 for (Field f : sorter.extensionFields) {
                     boolean fieldIsPresent = f.get(obj) != null;
                     UperEncoder.logger.debug("Extension {} is {}, presence encoded as <{}>", f.getName(),
-                            fieldIsPresent ? "present" : "absent", fieldIsPresent ? "1" : "0");
+                            fieldIsPresent ? PRESENT : ABSENT, fieldIsPresent ? "1" : "0");
                     bitbuffer.put(fieldIsPresent);
                 }
                 // Values of extensions themselves.
@@ -103,7 +106,7 @@ class SequenceCoder implements Decoder, Encoder {
         if (UperEncoder.hasExtensionMarker(annotations)) {
             extensionPresent = bitbuffer.get();
             UperEncoder.logger.debug("with extension marker, extension {}", extensionPresent ? "present!"
-                    : "absent");
+                    : ABSENT);
         }
         // Bitmask for optional fields.
         Deque<Boolean> optionalFieldsMask = new ArrayDeque<>(
@@ -111,7 +114,7 @@ class SequenceCoder implements Decoder, Encoder {
         for (Field f : sorter.optionalOrdinaryFields) {
             optionalFieldsMask.add(bitbuffer.get());
             UperEncoder.logger.debug("with optional field {} {}", f.getName(),
-                    optionalFieldsMask.getLast() ? "present" : "absent");
+                    optionalFieldsMask.getLast() ? PRESENT : ABSENT);
         }
         // All ordinary fields (fields within extension root).
         for (Field f : sorter.ordinaryFields) {
@@ -134,14 +137,14 @@ class SequenceCoder implements Decoder, Encoder {
             boolean[] bitmaskValueIsPresent = new boolean[numExtensions];
             for (int i = 0; i < numExtensions; i++) {
                 bitmaskValueIsPresent[i] = bitbuffer.get();
-                UperEncoder.logger.debug("extension {} is {}", i, bitmaskValueIsPresent[i] ? "present"
-                        : "absent");
+                UperEncoder.logger.debug("extension {} is {}", i, bitmaskValueIsPresent[i] ? PRESENT
+                        : ABSENT);
             }
             // Values.
             UperEncoder.logger.debug("decoding extensions values...");
             for (int i = 0; i < numExtensions; i++) {
                 UperEncoder.logger.debug("sequence extension {} {}", i,
-                        bitmaskValueIsPresent[i] ? "present" : "absent");
+                        bitmaskValueIsPresent[i] ? PRESENT : ABSENT);
                 if (bitmaskValueIsPresent[i]) {
                     UperEncoder.logger.debug("decoding extension {}...", i);
                     Field field = sorter.extensionFields.size() > i ? sorter.extensionFields

--- a/asn1-uper/src/main/java/net/gcdc/asn1/uper/StringCoder.java
+++ b/asn1-uper/src/main/java/net/gcdc/asn1/uper/StringCoder.java
@@ -18,6 +18,8 @@ import net.gcdc.asn1.datatypes.SizeRange;
 
 class StringCoder implements Decoder, Encoder {
 
+    private static final String  CHAR_DECORATION = "decoded more than one char (";
+
     @Override public <T> boolean canEncode(T obj, Annotation[] extraAnnotations) {
         return obj instanceof String || obj instanceof Asn1String;
     }
@@ -222,7 +224,7 @@ class StringCoder implements Decoder, Encoder {
                 byte charByte = (byte) UperEncoder.decodeConstrainedInt(bitqueue, UperEncoder.newRange(0, 127, false));
                 byte[] bytes = new byte[] { charByte };
                 String result = StandardCharsets.US_ASCII.decode(ByteBuffer.wrap(bytes)).toString();
-                if (result.length() != 1) { throw new AssertionError("decoded more than one char ("
+                if (result.length() != 1) { throw new AssertionError(CHAR_DECORATION
                         + result + ")"); }
                 return result;
             }
@@ -252,7 +254,7 @@ class StringCoder implements Decoder, Encoder {
                         String result = StandardCharsets.US_ASCII.decode(ByteBuffer.wrap(bytes))
                                 .toString();
                         if (result.length() != 1) { throw new AssertionError(
-                                "decoded more than one char (" + result + ")"); }
+                                CHAR_DECORATION + result + ")"); }
                         return result;
                     }
                 } else {  // Encode normally
@@ -261,7 +263,7 @@ class StringCoder implements Decoder, Encoder {
                     String result = StandardCharsets.US_ASCII.decode(ByteBuffer.wrap(bytes))
                             .toString();
                     if (result.length() != 1) { throw new AssertionError(
-                            "decoded more than one char (" + result + ")"); }
+                            CHAR_DECORATION + result + ")"); }
                     return result;
                 }
             }

--- a/camdenm/src/main/java/net/gcdc/camdenm/CoopIts.java
+++ b/camdenm/src/main/java/net/gcdc/camdenm/CoopIts.java
@@ -34,6 +34,10 @@ import net.gcdc.camdenm.CoopIts.ItsPduHeader.MessageId;
  */
 public class CoopIts {
 
+    private static final String ALREADY_CREATED = "Already created";
+    private static final String CANNOT_FIND_ELEMENT = "Can't find element in enum ";
+    private static final String FOR_CODE = " for code ";
+
     @Sequence
     public static class Cam {
         ItsPduHeader header;
@@ -296,7 +300,7 @@ public class CoopIts {
             private BasicVehicleContainerHighFrequency val = new BasicVehicleContainerHighFrequency();
             private boolean created = false;
             private void checkCreated() {
-                if (created) { throw new IllegalStateException("Already created"); }
+                if (created) { throw new IllegalStateException(ALREADY_CREATED); }
             }
             public BasicVehicleContainerHighFrequency create() { created = true; return val; }
 
@@ -542,8 +546,8 @@ public class CoopIts {
         private DriveDirection(int value) { this.value = value; }
         public static DriveDirection fromCode(int value) {
             for (DriveDirection element : values()) { if (element.value() == value) { return element; } }
-            throw new IllegalArgumentException("Can't find element in enum " +
-                    DriveDirection.class.getName() + " for code " + value);
+            throw new IllegalArgumentException(CANNOT_FIND_ELEMENT +
+                    DriveDirection.class.getName() + FOR_CODE + value);
         }
     }
 
@@ -902,7 +906,7 @@ public class CoopIts {
             private AccelerationControl val = new AccelerationControl();
             private boolean created = false;
             private void checkCreated() {
-                if (created) { throw new IllegalStateException("Already created"); }
+                if (created) { throw new IllegalStateException(ALREADY_CREATED); }
             }
             public AccelerationControl create() { created = true; return val; }
             private Builder() {}
@@ -1196,8 +1200,8 @@ public class CoopIts {
         private VehicleRole(int value) { this.value = value; }
         public static VehicleRole fromCode(int value) {
             for (VehicleRole element : values()) { if (element.value() == value) { return element; } }
-            throw new IllegalArgumentException("Can't find element in enum " +
-                    VehicleRole.class.getName() + " for code " + value);
+            throw new IllegalArgumentException(CANNOT_FIND_ELEMENT +
+                    VehicleRole.class.getName() + FOR_CODE + value);
         }
         public static boolean isMember(int value) { return value >= 0 && value <= 15; }
     }
@@ -1222,7 +1226,7 @@ public class CoopIts {
             private ExteriorLights val = new ExteriorLights();
             private boolean created = false;
             private void checkCreated() {
-                if (created) { throw new IllegalStateException("Already created"); }
+                if (created) { throw new IllegalStateException(ALREADY_CREATED); }
             }
             public ExteriorLights create() { created = true; return val; }
 
@@ -1690,8 +1694,8 @@ public class CoopIts {
         public static DangerousGoodsBasic defaultValue() { return explosives1; }
         public static DangerousGoodsBasic fromCode(int value) {
             for (DangerousGoodsBasic element : values()) { if (element.value() == value) { return element; } }
-            throw new IllegalArgumentException("Can't find element in enum " +
-                    DangerousGoodsBasic.class.getName() + " for code " + value);
+            throw new IllegalArgumentException(CANNOT_FIND_ELEMENT +
+                    DangerousGoodsBasic.class.getName() + FOR_CODE + value);
         }
 
     }

--- a/geonetworking/src/main/java/net/gcdc/BtpUdpClient.java
+++ b/geonetworking/src/main/java/net/gcdc/BtpUdpClient.java
@@ -37,6 +37,7 @@ public class BtpUdpClient {
     private final static String usage =
             "Usage: java -cp gn.jar BtpClient --local-udp2eth-port <local-port> --remote-udp2eth-address <udp-to-ethernet-remote-host-and-port> --local-data-port <port> --remote-data-address <host:port> --gpsd-server <host:port> --mac-address <xx:xx:xx:xx:xx:xx>" + "\n" +
     "BTP ports: 2001 (CAM), 2002 (DENM), 2003 (MAP), 2004 (SPAT).";
+    private static final String BAD_DATA = "Bad DATA host:port.\n";
 
     public static void main(String[] args) throws IOException {
         if (args.length < 7) {
@@ -73,7 +74,7 @@ public class BtpUdpClient {
             } else if (args[arg].startsWith("--remote-data-address")) {
                 arg++;
                 String[] hostPort = args[arg].split(":");
-                if (hostPort.length != 2) { System.err.println("Bad DATA host:port.\n" + usage); System.exit(1); }
+                if (hostPort.length != 2) { System.err.println(BAD_DATA + usage); System.exit(1); }
                 remoteDataAddress = new InetSocketAddress(hostPort[0], Integer.parseInt(hostPort[1]));
             } else if (args[arg].startsWith("--local-data-cam-port")) {
                 arg++;
@@ -81,7 +82,7 @@ public class BtpUdpClient {
             } else if (args[arg].startsWith("--remote-data-cam-address")) {
                 arg++;
                 String[] hostPort = args[arg].split(":");
-                if (hostPort.length != 2) { System.err.println("Bad DATA host:port.\n" + usage); System.exit(1); }
+                if (hostPort.length != 2) { System.err.println(BAD_DATA + usage); System.exit(1); }
                 remoteDataCamAddress = new InetSocketAddress(hostPort[0], Integer.parseInt(hostPort[1]));
             } else if (args[arg].startsWith("--local-data-iclcm-port")) {
                 arg++;
@@ -89,7 +90,7 @@ public class BtpUdpClient {
             } else if (args[arg].startsWith("--remote-data-iclcm-address")) {
                 arg++;
                 String[] hostPort = args[arg].split(":");
-                if (hostPort.length != 2) { System.err.println("Bad DATA host:port.\n" + usage); System.exit(1); }
+                if (hostPort.length != 2) { System.err.println(BAD_DATA + usage); System.exit(1); }
                 remoteDataIclcmAddress = new InetSocketAddress(hostPort[0], Integer.parseInt(hostPort[1]));
             } else if (args[arg].startsWith("--position")) {
                 arg++;


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1192 - “String literals should not be duplicated”. 
This PR will reduce 64 min TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1192
 Please let me know if you have any questions.
Fevzi Ozgul