### PR TITLE
Fixing squid: ModifiersOrderCheck  should be declared in the correct order

### DIFF
--- a/asn1-datatypes/src/main/java/net/gcdc/asn1/datatypes/Asn1SequenceOf.java
+++ b/asn1-datatypes/src/main/java/net/gcdc/asn1/datatypes/Asn1SequenceOf.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
  * @param <T> type of elements contained.
  */
 public abstract class Asn1SequenceOf<T> extends AbstractList<T> {
-    private final static Logger logger = LoggerFactory.getLogger(Asn1SequenceOf.class);
+    private static final Logger logger = LoggerFactory.getLogger(Asn1SequenceOf.class);
 
     private final List<T> bakingList;
 

--- a/asn1-uper/src/main/java/net/gcdc/asn1/uper/UperEncoder.java
+++ b/asn1-uper/src/main/java/net/gcdc/asn1/uper/UperEncoder.java
@@ -32,13 +32,13 @@ import org.slf4j.LoggerFactory;
 public class UperEncoder {
     final static Logger logger = LoggerFactory.getLogger(UperEncoder.class);
 
-    private final static int NUM_16K = 16384;
+    private static final int NUM_16K = 16384;
     @SuppressWarnings("unused")
-    private final static int NUM_32K = 32768;
+    private  static final int NUM_32K = 32768;
     @SuppressWarnings("unused")
-    private final static int NUM_48K = 49152;
+    private  static final int NUM_48K = 49152;
     @SuppressWarnings("unused")
-    private final static int NUM_64K = 65536;
+    private  static final int NUM_64K = 65536;
 
     public static <T> byte[] encode(T obj)
             throws IllegalArgumentException, UnsupportedOperationException {
@@ -496,7 +496,7 @@ public class UperEncoder {
         return result;
     }
 
-    final protected static char[] hexArray = "0123456789ABCDEF".toCharArray();
+    static final protected  char[] hexArray = "0123456789ABCDEF".toCharArray();
 
     public static String hexStringFromBytes(byte[] bytes) {
         char[] hexChars = new char[bytes.length * 2];

--- a/camdenm/src/main/java/net/gcdc/camdenm/CoopIts.java
+++ b/camdenm/src/main/java/net/gcdc/camdenm/CoopIts.java
@@ -741,7 +741,7 @@ public class CoopIts {
         private final int value;
         public int value() { return value; }
         private YawRateConfidence(int value) { this.value = value; }
-        static public boolean isMember(int value) { return value >= 0 && value <= 8; }
+        public static  boolean isMember(int value) { return value >= 0 && value <= 8; }
 
     }
 

--- a/geonetworking/src/main/java/net/gcdc/BtpStdinClient.java
+++ b/geonetworking/src/main/java/net/gcdc/BtpStdinClient.java
@@ -25,7 +25,7 @@ import org.threeten.bp.Instant;
 
 public class BtpStdinClient {
 
-    private final static String usage =
+    private static final  String usage =
             "Usage: java -cp gn.jar StdinClient --local-port <local-port> --remote-address <udp-to-ethernet-remote-host-and-port> <--has-ethernet-header | --no-ethernet-header> <--position <lat>,<lon> | --gpsd-server <host>:<port>> --btp-destination-port <port>" + "\n" +
     "BTP ports: 2001 (CAM), 2002 (DENM), 2003 (MAP), 2004 (SPAT).";
 

--- a/geonetworking/src/main/java/net/gcdc/BtpUdpClient.java
+++ b/geonetworking/src/main/java/net/gcdc/BtpUdpClient.java
@@ -32,9 +32,9 @@ import org.threeten.bp.Instant;
 
 public class BtpUdpClient {
 
-    private final static Logger logger = LoggerFactory.getLogger(BtpUdpClient.class);
+    private  static final Logger logger = LoggerFactory.getLogger(BtpUdpClient.class);
 
-    private final static String usage =
+    private  static final String usage =
             "Usage: java -cp gn.jar BtpClient --local-udp2eth-port <local-port> --remote-udp2eth-address <udp-to-ethernet-remote-host-and-port> --local-data-port <port> --remote-data-address <host:port> --gpsd-server <host:port> --mac-address <xx:xx:xx:xx:xx:xx>" + "\n" +
     "BTP ports: 2001 (CAM), 2002 (DENM), 2003 (MAP), 2004 (SPAT).";
 

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/BasicHeader.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/BasicHeader.java
@@ -90,9 +90,9 @@ public class BasicHeader {
             }
         }
 
-        final static double MAX_MULTIPLIER = 63;  // Max unsigned 6-bit integer.
+         static final double MAX_MULTIPLIER = 63;  // Max unsigned 6-bit integer.
 
-        public final static Lifetime MAX_VALUE = new Lifetime(Base.X100S, (byte)MAX_MULTIPLIER);
+        public static final Lifetime MAX_VALUE = new Lifetime(Base.X100S, (byte)MAX_MULTIPLIER);
 
         private final byte multiplier;  // bits 0-5
         private final Base base;        // bits 6-7

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/Destination.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/Destination.java
@@ -90,11 +90,11 @@ public abstract class Destination {
                 return false;
             return true;
         }
-        final private Area              area;
-        final private Optional<Double>  maxLifetimeSeconds;
-        final private Optional<Byte>    maxHopLimit;
-        final private Optional<Byte>    remainingHopLimit;
-        final private boolean           isAnycast;
+        private final Area              area;
+        private final Optional<Double>  maxLifetimeSeconds;
+        private final Optional<Byte>    maxHopLimit;
+        private final Optional<Byte>    remainingHopLimit;
+        private final  boolean           isAnycast;
 
         private Geobroadcast (
                 Area              area,

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/GeonetStation.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/GeonetStation.java
@@ -39,10 +39,10 @@ public class GeonetStation implements Runnable, AutoCloseable {
     private LocationTable locationTable;
     private final static Logger logger = LoggerFactory.getLogger(GeonetStation.class);
 
-    public final static short GN_ETHER_TYPE = (short) 0x8947;
-    private final static MacAddress BROADCAST_MAC = new MacAddress(0xff_ff_ff_ff_ff_ffL);
-    private final static MacAddress EMPTY_MAC = new MacAddress(0);
-    private final static int ETHER_HEADER_LENGTH = 14;
+    public  static final short GN_ETHER_TYPE = (short) 0x8947;
+    private static final  MacAddress BROADCAST_MAC = new MacAddress(0xff_ff_ff_ff_ff_ffL);
+    private static final MacAddress EMPTY_MAC = new MacAddress(0);
+    private static final int ETHER_HEADER_LENGTH = 14;
 
     // Common scheduler for beacon, Duplicate packet detection and Contention-based forwarding.
     // Change to custom-clock scheduler for non-real-time time. (Dependency injection?)

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/LinkLayerUdpToEthernet.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/LinkLayerUdpToEthernet.java
@@ -13,7 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class LinkLayerUdpToEthernet implements LinkLayer, AutoCloseable {
-    private final static Logger logger = LoggerFactory.getLogger(LinkLayerUdpToEthernet.class);
+    private static final Logger logger = LoggerFactory.getLogger(LinkLayerUdpToEthernet.class);
 
     final SocketAddress remoteAddress;
     final boolean hasEthernetHeader;
@@ -23,7 +23,7 @@ public class LinkLayerUdpToEthernet implements LinkLayer, AutoCloseable {
     final byte[] buffer = new byte[BUFFER_LENGTH];
     final DatagramPacket receptionPacket = new DatagramPacket(buffer, BUFFER_LENGTH);
 
-    private final static int ETHERTYPE_START_BIT = 12;
+    private static final int ETHERTYPE_START_BIT = 12;
 
     public LinkLayerUdpToEthernet(int localPort, SocketAddress remoteAddress, boolean hasEthernetHeader)
             throws SocketException {

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/LocationTable.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/LocationTable.java
@@ -19,7 +19,7 @@ import org.threeten.bp.Instant;
  * Entries in the Location Table expire after itsGnLifetimeLocTE.
  * */
 public class LocationTable {
-    private final static Logger logger = LoggerFactory.getLogger(LocationTable.class);
+    private static final Logger logger = LoggerFactory.getLogger(LocationTable.class);
 
     private final ConfigProvider configProvider;
 

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/LongPositionVector.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/LongPositionVector.java
@@ -103,8 +103,8 @@ public final class LongPositionVector {
     public static final int LENGTH = 24;
 
 
-    private final static double SPEED_STORE_SCALE   = 0.01;  // 0.01 meters per second.
-    private final static double HEADING_STORE_SCALE = 0.1;   // 0.1 degrees from north.
+    private static final double SPEED_STORE_SCALE   = 0.01;  // 0.01 meters per second.
+    private static final double HEADING_STORE_SCALE = 0.1;   // 0.1 degrees from north.
 
     private int speedAsStoreUnit(double speedMetersPerSecond) {
         return (int) Math.round(speedMetersPerSecond / SPEED_STORE_SCALE);

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/Position.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/Position.java
@@ -25,9 +25,9 @@ public final class Position {
         return "Pos(" + lattitudeDegrees + ", " + longitudeDegrees + ")";
     }
 
-    final static double MICRODEGREE = 1E-6;
-    final static double STORE_UNIT = 0.1 * MICRODEGREE;
-    final static double earthRadius = 6371000; // In meters. In miles: 3958.75;
+    static final double MICRODEGREE = 1E-6;
+    static final double STORE_UNIT = 0.1 * MICRODEGREE;
+    static final double earthRadius = 6371000; // In meters. In miles: 3958.75;
 
 
     private final double lattitudeDegrees;

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/gpsdclient/GpsdClient.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/gpsdclient/GpsdClient.java
@@ -34,7 +34,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 public class GpsdClient implements PositionProvider, AutoCloseable,TelnetNotificationHandler,Runnable {
-    private final static Logger logger = LoggerFactory.getLogger(GpsdClient.class);
+    private static final Logger logger = LoggerFactory.getLogger(GpsdClient.class);
 
     private TPV                   lastSeenTPV = null;
     private final Gson            gson        = new GsonBuilder().create();

--- a/uppertester/src/main/java/net/gcdc/uppertester/ItsStation.java
+++ b/uppertester/src/main/java/net/gcdc/uppertester/ItsStation.java
@@ -107,7 +107,7 @@ import com.lexicalscope.jewel.cli.Option;
  *
  */
 public class ItsStation implements AutoCloseable {
-    private final static Logger logger = LoggerFactory.getLogger(ItsStation.class);
+    private static final Logger logger = LoggerFactory.getLogger(ItsStation.class);
 
     private int defaultUpperTesterPort = 5000;
 
@@ -120,24 +120,24 @@ public class ItsStation implements AutoCloseable {
     private final ExecutorService executor = Executors.newCachedThreadPool();
     private final ScheduledExecutorService scheduledExecutor = Executors.newScheduledThreadPool(5);
 
-    private final static double MICRODEGREE = 1E-6;
-    private final static byte REPLY_SUCCESS = 0x01;
-    private final static byte REPLY_FAILURE = 0x00;
+    private static final double MICRODEGREE = 1E-6;
+    private static final byte REPLY_SUCCESS = 0x01;
+    private static final byte REPLY_FAILURE = 0x00;
 
-    private final static short PORT_CAM  = 2001;
-    private final static short PORT_DENM = 2002;
+    private static final short PORT_CAM  = 2001;
+    private static final short PORT_DENM = 2002;
 //    private final static short PORT_MAP  = 2003;
 //    private final static short PORT_SPAT = 2004;
 
-    private final static long CAM_INTERVAL_MIN_MS = 100;
-    private final static long CAM_INTERVAL_MAX_MS = 1000;
-    private final static long CAM_LOW_FREQ_INTERVAL_MS = 500;
+    private static final long CAM_INTERVAL_MIN_MS = 100;
+    private static final long CAM_INTERVAL_MAX_MS = 1000;
+    private static final long CAM_LOW_FREQ_INTERVAL_MS = 500;
 
-    private final static long CAM_INITIAL_DELAY_MS = 20;  // At startup.
+    private static final long CAM_INITIAL_DELAY_MS = 20;  // At startup.
 
-    private final static int HIGH_DYNAMICS_CAM_COUNT = 4;
+    private static final int HIGH_DYNAMICS_CAM_COUNT = 4;
 
-    public final static double CAM_LIFETIME_SECONDS = 0.9;
+    public static final double CAM_LIFETIME_SECONDS = 0.9;
 
     private final GeonetDataListener gnListener = new GeonetDataListener() {
         @Override public void onGeonetDataReceived(GeonetData indication) {

--- a/uppertester/src/main/java/net/gcdc/uppertester/Parser.java
+++ b/uppertester/src/main/java/net/gcdc/uppertester/Parser.java
@@ -13,7 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class Parser {
-    final static Logger logger = LoggerFactory.getLogger(Parser.class);
+    static final Logger logger = LoggerFactory.getLogger(Parser.class);
 
     private static final List<Class<?>> staticMessages = Arrays.asList(
             BtpEventIndication.class,

--- a/vehicle-adapter/src/main/java/net/gcdc/vehicle/LocalCam.java
+++ b/vehicle-adapter/src/main/java/net/gcdc/vehicle/LocalCam.java
@@ -28,7 +28,7 @@ import net.gcdc.asn1.datatypes.IntRange;
 import net.gcdc.asn1.datatypes.Asn1Integer;
 
 public class LocalCam{
-    private final static Logger logger = LoggerFactory.getLogger(VehicleAdapter.class);
+    private static final Logger logger = LoggerFactory.getLogger(VehicleAdapter.class);
     private final int LOCAL_CAM_LENGTH = 82;
     
     byte messageID = 2;

--- a/vehicle-adapter/src/main/java/net/gcdc/vehicle/LocalDenm.java
+++ b/vehicle-adapter/src/main/java/net/gcdc/vehicle/LocalDenm.java
@@ -25,7 +25,7 @@ import net.gcdc.camdenm.CoopIts.ItsPduHeader.ProtocolVersion;
 import net.gcdc.asn1.datatypes.IntRange;
 
 public class LocalDenm{
-    private final static Logger logger = LoggerFactory.getLogger(VehicleAdapter.class);
+    private static final Logger logger = LoggerFactory.getLogger(VehicleAdapter.class);
     private final int LOCAL_DENM_LENGTH = 101;
     /* TODO: Is this the right way to keep sequence numbers? */
     private static int denmSequenceNumber = 0;

--- a/vehicle-adapter/src/main/java/net/gcdc/vehicle/LocalIclcm.java
+++ b/vehicle-adapter/src/main/java/net/gcdc/vehicle/LocalIclcm.java
@@ -27,7 +27,7 @@ import net.gcdc.camdenm.Iclcm.*;
 import net.gcdc.asn1.datatypes.IntRange;
 
 public class LocalIclcm{
-    private final static Logger logger = LoggerFactory.getLogger(VehicleAdapter.class);
+    private static final Logger logger = LoggerFactory.getLogger(VehicleAdapter.class);
     private final int LOCAL_iCLCM_LENGTH = 111;
 
     byte messageID;

--- a/vehicle-adapter/src/main/java/net/gcdc/vehicle/VehicleAdapter.java
+++ b/vehicle-adapter/src/main/java/net/gcdc/vehicle/VehicleAdapter.java
@@ -140,7 +140,7 @@ import net.gcdc.geonetworking.Optional;
 import org.threeten.bp.Instant;
 
 public class VehicleAdapter {
-    private final static Logger logger = LoggerFactory.getLogger(VehicleAdapter.class);
+    private static final Logger logger = LoggerFactory.getLogger(VehicleAdapter.class);
 
     /* Sockets and GeonetStation used to send and receive BTP and UDP
      * packets. */
@@ -149,17 +149,17 @@ public class VehicleAdapter {
     private final BtpSocket btpSocket;
 
     /* BTP ports for CAM/DENM/iCLCM */
-    private final static short PORT_CAM  = 2001;
-    private final static short PORT_DENM = 2002;
-    private final static short PORT_ICLCM = 2010;
+    private static final short PORT_CAM  = 2001;
+    private static final short PORT_DENM = 2002;
+    private static final short PORT_ICLCM = 2010;
 
     /* Seconds for which the message is relevant. */
-    public final static double CAM_LIFETIME_SECONDS = 0.9;
-    public final static double iCLCM_LIFETIME_SECONDS = 0.9;
+    public static final double CAM_LIFETIME_SECONDS = 0.9;
+    public static final double iCLCM_LIFETIME_SECONDS = 0.9;
 
     /* Maximum size of the UDP buffer. Needs to be at least as large
      * as the maximum message size. */
-    public final static int MAX_UDP_LENGTH = 300;
+    public static final int MAX_UDP_LENGTH = 300;
 
     /* Ports and IP address used for communicating with the vehicle
      * control system. */


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:ModifiersOrderCheck - “Modifiers should be declared in the correct order”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:ModifiersOrderCheck
 Please let me know if you have any questions.
Fevzi Ozgul