### PR TITLE
Fixing squid: S1166   Exception handlers should preserve the original exception part 1

### DIFF
--- a/asn1-uper/src/main/java/net/gcdc/asn1/uper/StringCoder.java
+++ b/asn1-uper/src/main/java/net/gcdc/asn1/uper/StringCoder.java
@@ -15,8 +15,12 @@ import net.gcdc.asn1.datatypes.DefaultAlphabet;
 import net.gcdc.asn1.datatypes.FixedSize;
 import net.gcdc.asn1.datatypes.RestrictedString;
 import net.gcdc.asn1.datatypes.SizeRange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class StringCoder implements Decoder, Encoder {
+
+    private  static final Logger LOGGER = LoggerFactory.getLogger(StringCoder.class);
 
     @Override public <T> boolean canEncode(T obj, Annotation[] extraAnnotations) {
         return obj instanceof String || obj instanceof Asn1String;
@@ -173,6 +177,7 @@ class StringCoder implements Decoder, Encoder {
                     try {
                         chars = UperEncoder.instantiate(restriction.alphabet()).chars().toCharArray();
                     } catch (IllegalArgumentException e) {
+                        LOGGER.info("Uninstantinatable alphabet ", e);
                         throw new IllegalArgumentException("Uninstantinatable alphabet"
                                 + restriction.alphabet().getName());
                     }
@@ -233,6 +238,7 @@ class StringCoder implements Decoder, Encoder {
                     try {
                         chars = UperEncoder.instantiate(restrictionAnnotation.alphabet()).chars().toCharArray();
                     } catch (IllegalArgumentException e) {
+                        LOGGER.info("Uninstantinatable alphabet ", e);
                         throw new IllegalArgumentException("Uninstantinatable alphabet"
                                 + restrictionAnnotation.alphabet().getName());
                     }

--- a/geonetworking/src/main/java/net/gcdc/BtpStdinClient.java
+++ b/geonetworking/src/main/java/net/gcdc/BtpStdinClient.java
@@ -8,9 +8,8 @@ import java.io.PrintStream;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.SocketException;
-import java.util.logging.Level;
 
-import com.sun.istack.internal.logging.Logger;
+
 import net.gcdc.geonetworking.Address;
 import net.gcdc.geonetworking.BtpPacket;
 import net.gcdc.geonetworking.BtpSocket;
@@ -23,6 +22,7 @@ import net.gcdc.geonetworking.PositionProvider;
 import net.gcdc.geonetworking.StationConfig;
 import net.gcdc.geonetworking.gpsdclient.GpsdClient;
 
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.threeten.bp.Instant;
 import sun.util.logging.PlatformLogger;
@@ -33,7 +33,7 @@ public class BtpStdinClient {
             "Usage: java -cp gn.jar StdinClient --local-port <local-port> --remote-address <udp-to-ethernet-remote-host-and-port> <--has-ethernet-header | --no-ethernet-header> <--position <lat>,<lon> | --gpsd-server <host>:<port>> --btp-destination-port <port>" + "\n" +
     "BTP ports: 2001 (CAM), 2002 (DENM), 2003 (MAP), 2004 (SPAT).";
 
-    private static final Logger LOGGER = Logger.getLogger(BtpStdinClient.class);
+    private   static  final Logger LOGGER  = LoggerFactory.getLogger(BtpUdpClient.class);
 
     public static void main(String[] args) throws IOException {
         if (args.length < 7) {
@@ -116,7 +116,7 @@ public class BtpStdinClient {
                         dataToSend = br.readLine();  // Consecutive lines.
                     }
                 } catch (IOException e) {
-                    LOGGER.log(Level.WARNING, e.getMessage(), e);
+                    LOGGER.info("socket sen error ", e.getMessage(), e);
                 }
             }
         };

--- a/geonetworking/src/main/java/net/gcdc/BtpStdinClient.java
+++ b/geonetworking/src/main/java/net/gcdc/BtpStdinClient.java
@@ -25,7 +25,6 @@ import net.gcdc.geonetworking.gpsdclient.GpsdClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.threeten.bp.Instant;
-import sun.util.logging.PlatformLogger;
 
 public class BtpStdinClient {
 

--- a/geonetworking/src/main/java/net/gcdc/BtpStdinClient.java
+++ b/geonetworking/src/main/java/net/gcdc/BtpStdinClient.java
@@ -8,7 +8,9 @@ import java.io.PrintStream;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.SocketException;
+import java.util.logging.Level;
 
+import com.sun.istack.internal.logging.Logger;
 import net.gcdc.geonetworking.Address;
 import net.gcdc.geonetworking.BtpPacket;
 import net.gcdc.geonetworking.BtpSocket;
@@ -21,13 +23,17 @@ import net.gcdc.geonetworking.PositionProvider;
 import net.gcdc.geonetworking.StationConfig;
 import net.gcdc.geonetworking.gpsdclient.GpsdClient;
 
+import org.slf4j.LoggerFactory;
 import org.threeten.bp.Instant;
+import sun.util.logging.PlatformLogger;
 
 public class BtpStdinClient {
 
     private final static String usage =
             "Usage: java -cp gn.jar StdinClient --local-port <local-port> --remote-address <udp-to-ethernet-remote-host-and-port> <--has-ethernet-header | --no-ethernet-header> <--position <lat>,<lon> | --gpsd-server <host>:<port>> --btp-destination-port <port>" + "\n" +
     "BTP ports: 2001 (CAM), 2002 (DENM), 2003 (MAP), 2004 (SPAT).";
+
+    private static final Logger LOGGER = Logger.getLogger(BtpStdinClient.class);
 
     public static void main(String[] args) throws IOException {
         if (args.length < 7) {
@@ -110,7 +116,7 @@ public class BtpStdinClient {
                         dataToSend = br.readLine();  // Consecutive lines.
                     }
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    LOGGER.log(Level.WARNING, e.getMessage(), e);
                 }
             }
         };

--- a/geonetworking/src/main/java/net/gcdc/BtpUdpClient.java
+++ b/geonetworking/src/main/java/net/gcdc/BtpUdpClient.java
@@ -7,6 +7,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.SocketException;
 import java.util.Arrays;
+import java.util.logging.Level;
 
 import net.gcdc.geonetworking.Address;
 import net.gcdc.geonetworking.BtpPacket;
@@ -172,7 +173,7 @@ public class BtpUdpClient {
                                 ));
                     }
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    logger.info("data socket sending error " ,e);
                 }
             }
         };
@@ -193,7 +194,7 @@ public class BtpUdpClient {
                         socket.send(BtpPacket.singleHop(btpPayload, btpDestinationPort));
                     }
                 } catch (IOException e) {
-                    e.printStackTrace();
+                   logger.info("Datagram socket sending error ", e);
                 }
             }
         };
@@ -214,7 +215,7 @@ public class BtpUdpClient {
                         socket.send(BtpPacket.singleHop(btpPayload, btpDestinationPort));
                     }
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    logger.info("DatagramSocket error ", e);
                 }
             }
         };
@@ -268,7 +269,7 @@ public class BtpUdpClient {
                         }
                     }
                 } catch (IOException e) {
-                    e.printStackTrace();
+                   logger.info("BtpPacket error :", e);
                 }
             }
         };

--- a/geonetworking/src/main/java/net/gcdc/UdpDuplicator.java
+++ b/geonetworking/src/main/java/net/gcdc/UdpDuplicator.java
@@ -1,5 +1,8 @@
 package net.gcdc;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
@@ -9,6 +12,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 public class UdpDuplicator {
+
+    private  static final  Logger LOGGER = LoggerFactory.getLogger(BtpUdpClient.class);
 
     private class Client implements Runnable {
         public final int            localPort;
@@ -38,7 +43,7 @@ public class UdpDuplicator {
                 }
             } catch (IOException e) {
                 // TODO Auto-generated catch block
-                e.printStackTrace();
+               LOGGER.info("packetsending or receiving error ", e);
             }
         }
     }

--- a/geonetworking/src/main/java/net/gcdc/UdpDuplicator.java
+++ b/geonetworking/src/main/java/net/gcdc/UdpDuplicator.java
@@ -13,7 +13,7 @@ import java.util.Arrays;
 
 public class UdpDuplicator {
 
-    private  static final  Logger LOGGER = LoggerFactory.getLogger(BtpUdpClient.class);
+    private  static final  Logger LOGGER = LoggerFactory.getLogger(UdpDuplicator.class);
 
     private class Client implements Runnable {
         public final int            localPort;


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1166- “ Exception handlers should preserve the original exception”.
TD removal 80 min. 
 You can find more information about the issues here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1166
 Please let me know if you have any questions.
Fevzi Ozgul