### PR TITLE
Fixing squid: S1166 Exception handlers should preserve the original exception part 2

### DIFF
--- a/asn1-uper/src/main/java/net/gcdc/asn1/uper/IntCoder.java
+++ b/asn1-uper/src/main/java/net/gcdc/asn1/uper/IntCoder.java
@@ -9,11 +9,13 @@ import java.util.Map;
 
 import net.gcdc.asn1.datatypes.Asn1Integer;
 import net.gcdc.asn1.datatypes.IntRange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class IntCoder implements Encoder, Decoder {
 
     private static final Map<Class<?>, IntRange> DEFAULT_RANGE;
-
+    private static final Logger LOGGER = LoggerFactory.getLogger(IntCoder.class.getName());
     static {
         DEFAULT_RANGE = new HashMap<>();
         DEFAULT_RANGE.put(short.class, UperEncoder.newRange(Short.MIN_VALUE, Short.MAX_VALUE, false));
@@ -58,7 +60,9 @@ class IntCoder implements Encoder, Decoder {
             try {
                 constructor = classOfT.getConstructor(t);
             } catch (NoSuchMethodException e) {
+                LOGGER.info("Method not found error", e);
                 // ignore and try next
+
             } catch (SecurityException e) {
                 throw new IllegalArgumentException("can't access constructor of "
                         + classOfT.getName() + ": " + e);

--- a/geonetworking/src/main/java/net/gcdc/geonetworking/gpsdclient/GpsdClient.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/gpsdclient/GpsdClient.java
@@ -60,7 +60,7 @@ public class GpsdClient implements PositionProvider, AutoCloseable,TelnetNotific
         catch (InvalidTelnetOptionException e){
             logger.error("GpsdClient:Error registering option handlers: " + e.getMessage());
         } catch (IOException e) {
-			e.printStackTrace();
+            logger.error("IO Error : " + e.getMessage(), e);
 		}
 
         while (true){
@@ -123,7 +123,7 @@ public class GpsdClient implements PositionProvider, AutoCloseable,TelnetNotific
     		//ignore for printing
     		logger.debug("Json parsing error (NumberFormatException) :"+n.getMessage()+" :: "+line);
     	}catch(Exception e){
-    		e.printStackTrace();
+    		logger.info("Error " + e.getMessage(), e);
     		return;
     	}
     }
@@ -236,7 +236,7 @@ public class GpsdClient implements PositionProvider, AutoCloseable,TelnetNotific
             }
         } catch (IOException | InterruptedException e) {
             // TODO Auto-generated catch block
-            e.printStackTrace();
+           logger.info("Exception :"+e.getMessage(), e);
         }
         System.err.println("Stopping GpsdClient..");
     }

--- a/uppertester/src/main/java/net/gcdc/uppertester/Parser.java
+++ b/uppertester/src/main/java/net/gcdc/uppertester/Parser.java
@@ -83,7 +83,6 @@ public class Parser {
                 msgToId.put(msgType, c);
             } catch (InstantiationException | NoSuchFieldException | IllegalAccessException e) {
                 logger.error("Error adding class {}", c.getName());
-                e.printStackTrace();
             }
         }
     }


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1166- “ Exception handlers should preserve the original exception”. 
This PR will reduce 60 min TD.
 You can find more information about the issues here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1166
 Please let me know if you have any questions.
Fevzi Ozgul