### PR TITLE
Fixing squid:UselessImportCheck  useless imports should be removed

### DIFF
--- a/geonetworking/src/main/java/net/gcdc/plugtestcms4/DUTTableModel.java
+++ b/geonetworking/src/main/java/net/gcdc/plugtestcms4/DUTTableModel.java
@@ -1,10 +1,6 @@
 package net.gcdc.plugtestcms4;
 
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
-import javax.swing.JTable;
-import javax.swing.event.TableModelListener;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableModel;
 import net.gcdc.plugtestcms4.ping.PingStatus;

--- a/geonetworking/src/main/java/net/gcdc/plugtestcms4/LocationTableTableModel.java
+++ b/geonetworking/src/main/java/net/gcdc/plugtestcms4/LocationTableTableModel.java
@@ -1,14 +1,9 @@
 package net.gcdc.plugtestcms4;
 
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
-import javax.swing.JTable;
-import javax.swing.event.TableModelListener;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableModel;
 import net.gcdc.geonetworking.LocationTable;
-import net.gcdc.plugtestcms4.ping.PingStatus;
+
 
 public class LocationTableTableModel
 extends AbstractTableModel
@@ -26,6 +21,7 @@ implements TableModel
   @Override
   public int getColumnCount ()
   {
+
     return 1;
   }
 

--- a/geonetworking/src/main/java/net/gcdc/plugtestcms4/ping/PingSettings.java
+++ b/geonetworking/src/main/java/net/gcdc/plugtestcms4/ping/PingSettings.java
@@ -3,7 +3,6 @@ package net.gcdc.plugtestcms4.ping;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class PingSettings

--- a/geonetworking/src/main/java/net/gcdc/plugtestcms4/ping/PingStatusThread.java
+++ b/geonetworking/src/main/java/net/gcdc/plugtestcms4/ping/PingStatusThread.java
@@ -1,8 +1,7 @@
 package net.gcdc.plugtestcms4.ping;
 
-import java.io.BufferedReader;
+
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.net.InetAddress;
 import java.util.logging.Level;
 

--- a/vehicle-adapter/src/main/java/net/gcdc/vehicle/LocalCam.java
+++ b/vehicle-adapter/src/main/java/net/gcdc/vehicle/LocalCam.java
@@ -22,10 +22,9 @@ import java.nio.BufferOverflowException;
 import net.gcdc.camdenm.CoopIts.*;
 import net.gcdc.camdenm.CoopIts.ItsPduHeader.MessageId;
 import net.gcdc.camdenm.CoopIts.ItsPduHeader.ProtocolVersion;
-import java.lang.annotation.Annotation;
 import java.lang.IllegalArgumentException;
 import net.gcdc.asn1.datatypes.IntRange;
-import net.gcdc.asn1.datatypes.Asn1Integer;
+
 
 public class LocalCam{
     private final static Logger logger = LoggerFactory.getLogger(VehicleAdapter.class);

--- a/vehicle-adapter/src/main/java/net/gcdc/vehicle/LocalDenm.java
+++ b/vehicle-adapter/src/main/java/net/gcdc/vehicle/LocalDenm.java
@@ -18,7 +18,6 @@ package net.gcdc.vehicle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.nio.ByteBuffer;
-import java.nio.BufferOverflowException;
 import net.gcdc.camdenm.CoopIts.*;
 import net.gcdc.camdenm.CoopIts.ItsPduHeader.MessageId;
 import net.gcdc.camdenm.CoopIts.ItsPduHeader.ProtocolVersion;

--- a/vehicle-adapter/src/main/java/net/gcdc/vehicle/LocalIclcm.java
+++ b/vehicle-adapter/src/main/java/net/gcdc/vehicle/LocalIclcm.java
@@ -17,9 +17,8 @@ package net.gcdc.vehicle;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.nio.ByteBuffer;
-import java.nio.BufferOverflowException;
 
+import java.nio.ByteBuffer;
 import net.gcdc.camdenm.CoopIts.*;
 import net.gcdc.camdenm.CoopIts.ItsPduHeader.MessageId;
 import net.gcdc.camdenm.CoopIts.ItsPduHeader.ProtocolVersion;

--- a/vehicle-adapter/src/main/java/net/gcdc/vehicle/VehicleAdapter.java
+++ b/vehicle-adapter/src/main/java/net/gcdc/vehicle/VehicleAdapter.java
@@ -29,7 +29,6 @@ import net.gcdc.asn1.uper.UperEncoder;
 import net.gcdc.camdenm.CoopIts.Cam;
 import net.gcdc.camdenm.CoopIts.Denm;
 import net.gcdc.geonetworking.Area;
-import net.gcdc.geonetworking.Area.*;
 import net.gcdc.geonetworking.BtpPacket;
 import net.gcdc.geonetworking.BtpSocket;
 import net.gcdc.geonetworking.Destination.Geobroadcast;
@@ -45,11 +44,10 @@ import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
 import java.net.InetAddress;
-import java.net.UnknownHostException;
+
 
 import com.lexicalscope.jewel.cli.ArgumentValidationException;
 import com.lexicalscope.jewel.cli.CliFactory;
-import com.lexicalscope.jewel.cli.InvalidOptionSpecificationException;
 import com.lexicalscope.jewel.cli.Option;
 
 /*
@@ -123,19 +121,17 @@ import net.gcdc.camdenm.CoopIts.YawRate;
 import net.gcdc.camdenm.CoopIts.YawRateConfidence;
 import net.gcdc.camdenm.CoopIts.YawRateValue;
 */
-import net.gcdc.camdenm.CoopIts.*;
+
 import net.gcdc.camdenm.CoopIts.ItsPduHeader.MessageId;
-import net.gcdc.camdenm.CoopIts.ItsPduHeader.ProtocolVersion;
+
 
 import net.gcdc.camdenm.Iclcm.*;
 
 import net.gcdc.geonetworking.LinkLayerUdpToEthernet;
 import net.gcdc.geonetworking.LongPositionVector;
-import net.gcdc.geonetworking.Position;
-import net.gcdc.geonetworking.StationConfig;
+
 import net.gcdc.geonetworking.Address;
-import net.gcdc.geonetworking.Optional;
-//import net.gcdc.geonetworking.StationType;
+
 
 import org.threeten.bp.Instant;
 


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:UselessImportCheck  - “  useless import  lines should be removed ”. 
This PR will remove 48 min TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:UselessImportCheck 
 Please let me know if you have any questions.
Fevzi Ozgul