### PR TITLE
Fixing squid: S1700 A field should not duplicate the name of its containing class

### DIFF
--- a/camdenm/src/main/java/net/gcdc/camdenm/CoopIts.java
+++ b/camdenm/src/main/java/net/gcdc/camdenm/CoopIts.java
@@ -37,23 +37,23 @@ public class CoopIts {
     @Sequence
     public static class Cam {
         ItsPduHeader header;
-        CoopAwareness cam;
+        CoopAwareness camField;
 
         public Cam(ItsPduHeader itsPduHeader, CoopAwareness coopAwareness) {
             this.header = itsPduHeader;
-            this.cam = coopAwareness;
+            this.camField = coopAwareness;
         }
 
         public Cam() { this(new ItsPduHeader(new MessageId(MessageId.cam)), new CoopAwareness()); }
 
-        @Override public String toString() { return "CAM(" + header + ", " + cam + ")"; }
+        @Override public String toString() { return "CAM(" + header + ", " + camField + ")"; }
 
 		public ItsPduHeader getHeader() {
 			return header;
 		}
 
 		public CoopAwareness getCam() {
-			return cam;
+			return camField;
 		}
     }
 

--- a/camdenm/src/main/java/net/gcdc/camdenm/Iclcm.java
+++ b/camdenm/src/main/java/net/gcdc/camdenm/Iclcm.java
@@ -500,7 +500,7 @@ public final  class Iclcm {
 	@IntRange(minValue = 0, maxValue = 1)
 	public static class MergeRequest extends Asn1Integer {
 		public static final int noMergeRequest = 0;
-		public static final int mergeRequest = 1;
+		public static final int mergeRequestNo = 1;
 		
 		public MergeRequest() { this(noMergeRequest); }
 		public MergeRequest(int value) { super(value); }
@@ -622,9 +622,9 @@ public final  class Iclcm {
 	
 	@IntRange(minValue = 1, maxValue = 1)
 	public static class EndOfScenario extends Asn1Integer {
-		public static final int endOfScenario = 1;
+		public static final int endOfScenarioNo = 1;
 		
-		public EndOfScenario() { this(endOfScenario); }
+		public EndOfScenario() { this(endOfScenarioNo); }
 		public EndOfScenario(int value) { super(value); }
 	}
 	


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1700 - “A field should not duplicate the name of its class”. 
This PR will reduce 50 min of TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1700
 Please let me know if you have any questions.
Fevzi Ozgul