### PR TITLE
Fixing squid: S2160 Subclasses that add fields should override "equals"

### DIFF
--- a/asn1-datatypes/src/main/java/net/gcdc/asn1/datatypes/Asn1SequenceOf.java
+++ b/asn1-datatypes/src/main/java/net/gcdc/asn1/datatypes/Asn1SequenceOf.java
@@ -1,10 +1,7 @@
 package net.gcdc.asn1.datatypes;
 
 import java.lang.reflect.ParameterizedType;
-import java.util.AbstractList;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,5 +47,19 @@ public abstract class Asn1SequenceOf<T> extends AbstractList<T> {
                 ((ParameterizedType)getClass().getGenericSuperclass()).getActualTypeArguments()[0],
                 coll);
         bakingList = new ArrayList<>(coll);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        Asn1SequenceOf<?> that = (Asn1SequenceOf<?>) o;
+        return Objects.equals(bakingList, that.bakingList);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), bakingList);
     }
 }

--- a/asn1-datatypes/src/main/java/net/gcdc/asn1/datatypes/Asn1VarSizeBitstring.java
+++ b/asn1-datatypes/src/main/java/net/gcdc/asn1/datatypes/Asn1VarSizeBitstring.java
@@ -3,6 +3,7 @@ package net.gcdc.asn1.datatypes;
 import java.util.AbstractList;
 import java.util.BitSet;
 import java.util.Collection;
+import java.util.Objects;
 
 public class Asn1VarSizeBitstring extends AbstractList<Boolean> {
 
@@ -37,4 +38,17 @@ public class Asn1VarSizeBitstring extends AbstractList<Boolean> {
         return backing.get(bitIndex);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        Asn1VarSizeBitstring booleen = (Asn1VarSizeBitstring) o;
+        return Objects.equals(backing, booleen.backing);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), backing);
+    }
 }


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2160 - “Subclasses that add fields should override ""equals""”. 
This PR will reduce 60 min TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2160
 Please let me know if you have any questions.
Fevzi Ozgul