### PR TITLE
Binary right shift Bug on get Lifetime fromByte

### DIFF
--- a/geonetworking/src/main/java/net/gcdc/geonetworking/BasicHeader.java
+++ b/geonetworking/src/main/java/net/gcdc/geonetworking/BasicHeader.java
@@ -126,7 +126,7 @@ public class BasicHeader {
         }
 
         public static Lifetime fromByte(byte b) {
-            byte multiplier = (byte) (b >> 2);           // Drop bits 6-7, keep only bits 0-5.
+            byte multiplier = (byte) ((b >> 2)& 0b0011_1111);   // Drop bits 6-7, keep only bits 0-5.
             Base base = Base.fromCode(b & 0b0000_0011);  // Keep only bits 6-7.
             return new Lifetime(base, multiplier);
         }


### PR DESCRIPTION
Problem Binary right shift in Java

Replicate Problem

If for example the value is 0xF3 (binary 11110011) to represent (Multiplier: 60, Base:3)

Then (11110011 >> 2) will produce 11111100
But if ((11110011 >> 2)& 0b0011_1111) will produce 00111100 (decimal 60)
Other solution is to use >>>

Java and right shift.

* >> (Signed right shift) 
* >>> (Unsigned right shift) 

Reference

* https://docs.oracle.com/javase/tutorial/java/nutsandbolts/op3.html
* https://www.vojtechruzicka.com/bit-manipulation-java-bitwise-bit-shift-operations/